### PR TITLE
Redirect blog titles to Notion

### DIFF
--- a/apps/web/app/api/blog/route.ts
+++ b/apps/web/app/api/blog/route.ts
@@ -113,7 +113,7 @@ export async function GET(request: Request) {
       id: page.id,
       title: parseTitle(properties.title),
       description: parseRichText(properties.description),
-      url: (page as any).url,
+      url: (page as any).public_url || (page as any).url,
       createdAt: parseCreatedTime(properties.createdAt),
       blocks,
     };
@@ -129,7 +129,7 @@ export async function GET(request: Request) {
       id: page.id,
       title: parseTitle(properties.title),
       description: parseRichText(properties.description),
-      url: page.url,
+      url: page.public_url || page.url,
       createdAt: parseCreatedTime(properties.createdAt),
     };
   });

--- a/apps/web/components/blog/BlogCard.tsx
+++ b/apps/web/components/blog/BlogCard.tsx
@@ -1,5 +1,4 @@
 import { motion } from "motion/react";
-import Link from "next/link";
 import type { NotionPost } from "../../app/blog/page";
 
 interface BlogCardProps {
@@ -9,7 +8,7 @@ interface BlogCardProps {
 
 export default function BlogCard({ post, index = 0 }: BlogCardProps) {
   return (
-    <Link href={`/blog/${post.id}`} className="block h-full">
+    <a href={post.url} className="block h-full">
       <motion.div
         key={post.id}
         className="group relative h-full bg-white/60 backdrop-blur-sm rounded-2xl overflow-hidden border border-white/60 hover:border-[var(--color-primary)]/30 transition-all duration-300 shadow-lg hover:shadow-2xl cursor-pointer hover:scale-105"
@@ -64,6 +63,6 @@ export default function BlogCard({ post, index = 0 }: BlogCardProps) {
           </div>
         </div>
       </motion.div>
-    </Link>
+    </a>
   );
 }


### PR DESCRIPTION
## Summary
- redirect blog card clicks to the original Notion page instead of an internal detail view
- use Notion's `public_url` so links open the deployed `milliwonkim.notion.site` pages

## Testing
- `pnpm lint` (apps/web)
- `pnpm check-types` (apps/web)
- `pnpm lint --filter web` *(fails: @repo/ui lint error)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c77d38b88322ba1c5dc906b2d350