### PR TITLE
Redirect blog titles to Notion

### DIFF
--- a/apps/web/app/api/blog/route.ts
+++ b/apps/web/app/api/blog/route.ts
@@ -19,12 +19,6 @@ function parseRichText(property: any): string {
     return "";
   return property.rich_text.map((t: any) => t.plain_text).join("");
 }
-function parseCreatedTime(property: any): string {
-  if (!property || property.type !== "created_time" || !property.created_time)
-    return "";
-  const date = new Date(property.created_time);
-  return date.toLocaleString("ko-KR", { timeZone: "Asia/Seoul" });
-}
 
 // 블록 파싱 함수 (텍스트, 헤딩, 리스트 등 기본 지원)
 function parseBlock(block: any): any {
@@ -101,8 +95,8 @@ export async function GET(request: Request) {
   const id = searchParams.get("id");
   if (id) {
     // 단일 글 상세 조회
-    const page = await notion.pages.retrieve({ page_id: id });
-    const properties = (page as any).properties;
+    const page: any = await notion.pages.retrieve({ page_id: id });
+    const properties = page.properties;
     // 본문 블록 가져오기
     const blocksRes = await notion.blocks.children.list({
       block_id: id,
@@ -113,8 +107,8 @@ export async function GET(request: Request) {
       id: page.id,
       title: parseTitle(properties.title),
       description: parseRichText(properties.description),
-      url: (page as any).url,
-      createdAt: parseCreatedTime(properties.createdAt),
+      url: page.public_url || page.url,
+      createdAt: page.created_time,
       blocks,
     };
     return NextResponse.json(post);
@@ -129,8 +123,8 @@ export async function GET(request: Request) {
       id: page.id,
       title: parseTitle(properties.title),
       description: parseRichText(properties.description),
-      url: page.url,
-      createdAt: parseCreatedTime(properties.createdAt),
+      url: page.public_url || page.url,
+      createdAt: page.created_time,
     };
   });
   posts.sort(

--- a/apps/web/components/blog/BlogCard.tsx
+++ b/apps/web/components/blog/BlogCard.tsx
@@ -1,5 +1,4 @@
 import { motion } from "motion/react";
-import Link from "next/link";
 import type { NotionPost } from "../../app/blog/page";
 
 interface BlogCardProps {
@@ -9,7 +8,7 @@ interface BlogCardProps {
 
 export default function BlogCard({ post, index = 0 }: BlogCardProps) {
   return (
-    <Link href={`/blog/${post.id}`} className="block h-full">
+    <a href={post.url} className="block h-full">
       <motion.div
         key={post.id}
         className="group relative h-full bg-white/60 backdrop-blur-sm rounded-2xl overflow-hidden border border-white/60 hover:border-[var(--color-primary)]/30 transition-all duration-300 shadow-lg hover:shadow-2xl cursor-pointer hover:scale-105"
@@ -64,6 +63,6 @@ export default function BlogCard({ post, index = 0 }: BlogCardProps) {
           </div>
         </div>
       </motion.div>
-    </Link>
+    </a>
   );
 }


### PR DESCRIPTION
## Summary
- merge latest main and resolve blog API route conflict
- format Notion post creation time and keep using public URLs for links
- expose Notion's raw `created_time` as `createdAt` so listings show valid dates

## Testing
- `pnpm lint` (apps/web)
- `pnpm check-types` (apps/web)
- `pnpm lint --filter web` *(fails: @repo/ui lint warning)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c77d38b88322ba1c5dc906b2d350