### PR TITLE
feat: refine light and dark theme styling

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,16 +1,18 @@
 @import "tailwindcss";
 
 :root {
+  color-scheme: light;
+
   /* 현대적인 애니메이션 이징 */
   --transition-smooth: cubic-bezier(0.165, 0.84, 0.44, 1);
   --transition-bounce: cubic-bezier(0.68, -0.55, 0.265, 1.55);
 
   /* 기본 테마 색상 */
-  --color-primary: #3b82f6; /* Blue 500 */
-  --color-primary-hover: #2563eb; /* Blue 600 */
-  --color-primary-light: #bfdbfe; /* Blue 200 */
+  --color-primary: #3b82f6;
+  --color-primary-hover: #2563eb;
+  --color-primary-light: #bfdbfe;
 
-  /* 테마 컬러 (새로운 Primary에 맞춰 조정) */
+  /* 테마 컬러 (Blue 계열) */
   --color-blue-50: #eff6ff;
   --color-blue-100: #dbeafe;
   --color-blue-200: #bfdbfe;
@@ -22,50 +24,166 @@
   --color-blue-800: #1e40af;
   --color-blue-900: #1e3a8a;
 
-  /* 추가 색상: 보라색 (Vite 로고 등) */
+  /* 추가 포인트 컬러 */
   --color-purple-500: #646cff;
 
   /* 기본 중립 색상 (Tailwind Slate 기반) */
-  --color-background: #ffffff; /* 기본 배경: 흰색 */
-  --color-foreground: #0f172a; /* Slate 900 - 기본 텍스트 */
+  --color-background: #f5f7ff;
+  --color-foreground: #0f172a;
   --color-white: #ffffff;
   --color-black: #000000;
-  --color-gray-50: #f8fafc; /* Slate 50 - 밝은 배경 또는 카드 배경 */
-  --color-gray-100: #f1f5f9; /* Slate 100 - 연한 구분선, 보조 배경 */
-  --color-gray-200: #e2e8f0; /* Slate 200 - 구분선 */
-  --color-gray-300: #cbd5e1; /* Slate 300 - 보더, 비활성 요소 */
-  --color-gray-400: #94a3b8; /* Slate 400 - 보조 텍스트 */
-  --color-gray-500: #64748b; /* Slate 500 - 좀 더 어두운 보조 텍스트 */
-  --color-gray-600: #475569; /* Slate 600 - 일반 텍스트 */
-  --color-gray-700: #334155; /* Slate 700 - 강조 텍스트 */
-  --color-gray-800: #1e293b; /* Slate 800 */
-  --color-gray-900: #0f172a; /* Slate 900 - 가장 어두운 텍스트, 제목 */
+  --color-gray-50: #f8fafc;
+  --color-gray-100: #f1f5f9;
+  --color-gray-200: #e2e8f0;
+  --color-gray-300: #cbd5e1;
+  --color-gray-400: #94a3b8;
+  --color-gray-500: #64748b;
+  --color-gray-600: #475569;
+  --color-gray-700: #334155;
+  --color-gray-800: #1e293b;
+  --color-gray-900: #0f172a;
 
   /* 컴포넌트별 색상 */
-  --color-card-background: var(--color-gray-50); /* 카드 배경은 약간의 회색 */
-  --color-card-border: var(--color-gray-200);
-  --color-card-shadow: rgba(0, 0, 0, 0.05);
-  --color-card-shadow-hover: rgba(0, 0, 0, 0.07);
+  --color-card-background: rgba(255, 255, 255, 0.86);
+  --color-card-border: rgba(148, 163, 184, 0.18);
+  --color-card-shadow: rgba(15, 23, 42, 0.06);
+  --color-card-shadow-hover: rgba(15, 23, 42, 0.15);
 
-  --color-input-background: var(--color-white);
-  --color-input-border: var(--color-gray-300);
-  --color-input-focus-ring: rgba(59, 130, 246, 0.25);
+  --color-input-background: rgba(255, 255, 255, 0.95);
+  --color-input-border: rgba(148, 163, 184, 0.24);
+  --color-input-focus-ring: rgba(59, 130, 246, 0.18);
   --color-input-focus-border: var(--color-primary);
 
   --color-button-primary: var(--color-primary);
   --color-button-primary-hover: var(--color-primary-hover);
-  --color-button-secondary: var(--color-gray-100);
-  --color-button-secondary-hover: var(--color-gray-200);
+  --color-button-secondary: rgba(241, 245, 249, 0.85);
+  --color-button-secondary-hover: rgba(226, 232, 240, 0.9);
 
   --color-text-primary: var(--color-gray-900);
   --color-text-secondary: var(--color-gray-600);
-  --color-text-tertiary: var(--color-gray-400); /* 기존 gray-500에서 변경 */
+  --color-text-tertiary: var(--color-gray-400);
   --color-text-inverse: var(--color-white);
 
-  --color-border-light: var(--color-gray-200);
-  --color-border-normal: var(--color-gray-300);
+  --color-border-light: rgba(148, 163, 184, 0.2);
+  --color-border-normal: rgba(148, 163, 184, 0.32);
 
-  --color-overlay: rgba(15, 23, 42, 0.5); /* Slate 900 기반 Overlay */
+  --color-overlay: rgba(15, 23, 42, 0.4);
+
+  /* 글래스모피즘 및 토글용 커스텀 변수 */
+  --app-gradient: radial-gradient(
+      circle at 12% 0%,
+      rgba(59, 130, 246, 0.16),
+      transparent 60%
+    ),
+    radial-gradient(
+      circle at 88% 5%,
+      rgba(14, 165, 233, 0.12),
+      transparent 62%
+    ),
+    linear-gradient(180deg, #f5f7ff 0%, #ffffff 45%, #f8fafc 100%);
+  --app-overlay: radial-gradient(
+      circle at 18% 28%,
+      rgba(99, 102, 241, 0.16),
+      transparent 68%
+    ),
+    radial-gradient(
+      circle at 80% 20%,
+      rgba(59, 130, 246, 0.12),
+      transparent 60%
+    ),
+    radial-gradient(
+      circle at 50% 90%,
+      rgba(16, 185, 129, 0.1),
+      transparent 70%
+    );
+  --app-surface: rgba(255, 255, 255, 0.72);
+  --app-surface-strong: rgba(255, 255, 255, 0.92);
+  --app-surface-border: rgba(148, 163, 184, 0.18);
+  --app-surface-border-strong: rgba(148, 163, 184, 0.32);
+  --app-shadow-soft: 0 24px 45px -25px rgba(15, 23, 42, 0.25);
+  --app-shadow-strong: 0 38px 70px -32px rgba(15, 23, 42, 0.35);
+  --app-toggle-track: rgba(255, 255, 255, 0.9);
+  --app-toggle-thumb: #ffffff;
+  --app-toggle-thumb-shadow: rgba(15, 23, 42, 0.18);
+  --app-toggle-icon: rgba(71, 85, 105, 0.78);
+  --app-glass-blur: 18px;
+}
+
+html[data-theme="dark"] {
+  color-scheme: dark;
+
+  --color-background: #020617;
+  --color-foreground: #e2e8f0;
+  --color-gray-50: #0f172a;
+  --color-gray-100: #111827;
+  --color-gray-200: #1e293b;
+  --color-gray-300: #334155;
+  --color-gray-400: #475569;
+  --color-gray-500: #64748b;
+  --color-gray-600: #94a3b8;
+  --color-gray-700: #cbd5f5;
+  --color-gray-800: #e2e8f0;
+  --color-gray-900: #f8fafc;
+
+  --color-card-background: rgba(15, 23, 42, 0.72);
+  --color-card-border: rgba(148, 163, 184, 0.2);
+  --color-card-shadow: rgba(2, 6, 23, 0.6);
+  --color-card-shadow-hover: rgba(2, 6, 23, 0.75);
+
+  --color-input-background: rgba(15, 23, 42, 0.85);
+  --color-input-border: rgba(148, 163, 184, 0.28);
+  --color-input-focus-ring: rgba(59, 130, 246, 0.3);
+  --color-input-focus-border: rgba(96, 165, 250, 0.9);
+
+  --color-button-secondary: rgba(15, 23, 42, 0.82);
+  --color-button-secondary-hover: rgba(30, 41, 59, 0.85);
+
+  --color-text-primary: #e2e8f0;
+  --color-text-secondary: #94a3b8;
+  --color-text-tertiary: #64748b;
+  --color-text-inverse: #0f172a;
+
+  --color-border-light: rgba(148, 163, 184, 0.18);
+  --color-border-normal: rgba(148, 163, 184, 0.35);
+
+  --color-overlay: rgba(2, 6, 23, 0.7);
+
+  --app-gradient: radial-gradient(
+      circle at 12% 4%,
+      rgba(59, 130, 246, 0.28),
+      transparent 60%
+    ),
+    radial-gradient(
+      circle at 88% 10%,
+      rgba(14, 165, 233, 0.22),
+      transparent 62%
+    ),
+    linear-gradient(180deg, #020617 0%, #0b1120 45%, #020617 100%);
+  --app-overlay: radial-gradient(
+      circle at 18% 24%,
+      rgba(59, 130, 246, 0.35),
+      transparent 68%
+    ),
+    radial-gradient(
+      circle at 80% 18%,
+      rgba(56, 189, 248, 0.2),
+      transparent 60%
+    ),
+    radial-gradient(
+      circle at 42% 90%,
+      rgba(30, 64, 175, 0.18),
+      transparent 70%
+    );
+  --app-surface: rgba(15, 23, 42, 0.72);
+  --app-surface-strong: rgba(15, 23, 42, 0.85);
+  --app-surface-border: rgba(59, 130, 246, 0.18);
+  --app-surface-border-strong: rgba(96, 165, 250, 0.28);
+  --app-shadow-soft: 0 30px 60px -28px rgba(2, 6, 23, 0.75);
+  --app-shadow-strong: 0 40px 80px -35px rgba(2, 6, 23, 0.92);
+  --app-toggle-track: rgba(15, 23, 42, 0.9);
+  --app-toggle-thumb: #f8fafc;
+  --app-toggle-thumb-shadow: rgba(2, 6, 23, 0.68);
+  --app-toggle-icon: rgba(226, 232, 240, 0.92);
 }
 
 /* 전역 스타일 */
@@ -84,6 +202,50 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   line-height: 1.6;
+  margin: 0;
+  min-height: 100vh;
+  color: var(--color-text-primary);
+  background-color: var(--color-background);
+  background-image: var(--app-gradient);
+  background-attachment: fixed;
+  background-size: cover;
+  transition:
+    color 0.4s var(--transition-smooth),
+    background-color 0.6s var(--transition-smooth),
+    background-image 0.6s var(--transition-smooth);
+  position: relative;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background: var(--app-overlay);
+  opacity: 0.9;
+  transition:
+    opacity 0.6s var(--transition-smooth),
+    background 0.6s var(--transition-smooth);
+}
+
+html[data-theme="dark"] body::before {
+  opacity: 0.7;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.3s var(--transition-smooth);
+}
+
+a:hover {
+  color: var(--color-primary);
+}
+
+::selection {
+  background: rgba(59, 130, 246, 0.25);
+  color: var(--color-text-inverse);
 }
 
 button {
@@ -218,6 +380,117 @@ button {
   .container {
     max-width: 640px;
   }
+}
+
+/* 상단 네비게이션 글래스 효과 */
+.nav-surface {
+  background: var(--app-surface);
+  border-bottom: 1px solid var(--app-surface-border);
+  box-shadow: var(--app-shadow-soft);
+  backdrop-filter: blur(var(--app-glass-blur));
+  -webkit-backdrop-filter: blur(var(--app-glass-blur));
+  transition:
+    background 0.45s var(--transition-smooth),
+    border-color 0.45s var(--transition-smooth),
+    box-shadow 0.45s var(--transition-smooth);
+}
+
+.nav-surface--scrolled {
+  background: var(--app-surface-strong);
+  border-color: var(--app-surface-border-strong);
+  box-shadow: var(--app-shadow-strong);
+}
+
+/* 토글 버튼 (다크/라이트) */
+.theme-toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.25rem;
+  width: 3.5rem;
+  height: 1.9rem;
+  padding: 0 0.4rem;
+  border-radius: 999px;
+  border: 1px solid var(--app-surface-border);
+  background: var(--app-toggle-track);
+  color: var(--app-toggle-icon);
+  box-shadow: 0 16px 28px rgba(15, 23, 42, 0.12);
+  transition:
+    background 0.4s var(--transition-smooth),
+    border-color 0.4s var(--transition-smooth),
+    box-shadow 0.4s var(--transition-smooth),
+    transform 0.25s var(--transition-bounce);
+}
+
+.theme-toggle:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 36px rgba(15, 23, 42, 0.18);
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid rgba(96, 165, 250, 0.55);
+  outline-offset: 3px;
+}
+
+html[data-theme="dark"] .theme-toggle {
+  box-shadow: 0 24px 42px rgba(2, 6, 23, 0.55);
+}
+
+.theme-toggle__thumb {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  height: 1.45rem;
+  width: 1.45rem;
+  border-radius: 999px;
+  background: var(--app-toggle-thumb);
+  box-shadow: 0 8px 18px var(--app-toggle-thumb-shadow);
+}
+
+.theme-toggle .sun-icon,
+.theme-toggle .moon-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.1rem;
+  height: 1.1rem;
+  opacity: 0.6;
+  transition:
+    opacity 0.35s var(--transition-smooth),
+    transform 0.35s var(--transition-smooth),
+    color 0.35s var(--transition-smooth);
+}
+
+.theme-toggle .sun-icon svg,
+.theme-toggle .moon-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+html[data-theme="light"] .theme-toggle .sun-icon {
+  color: #fbbf24;
+  opacity: 1;
+  transform: scale(1.05);
+}
+
+html[data-theme="light"] .theme-toggle .moon-icon {
+  opacity: 0.45;
+}
+
+html[data-theme="dark"] .theme-toggle {
+  border-color: var(--app-surface-border);
+  background: var(--app-toggle-track);
+}
+
+html[data-theme="dark"] .theme-toggle .moon-icon {
+  color: #60a5fa;
+  opacity: 1;
+  transform: scale(1.05);
+}
+
+html[data-theme="dark"] .theme-toggle .sun-icon {
+  opacity: 0.45;
 }
 
 @media (min-width: 768px) {

--- a/apps/web/components/ThemeToggle.tsx
+++ b/apps/web/components/ThemeToggle.tsx
@@ -46,9 +46,11 @@ export default function ThemeToggle() {
 
   return (
     <motion.button
+      type="button"
       className="theme-toggle"
       onClick={toggleTheme}
       aria-label={`테마 전환: 현재 ${theme === "light" ? "라이트" : "다크"} 모드`}
+      aria-pressed={theme === "dark"}
       whileTap={{ scale: 0.95 }}
     >
       <span className="sun-icon">
@@ -90,13 +92,20 @@ export default function ThemeToggle() {
         </svg>
       </span>
       <motion.span
-        className="absolute top-1/2 -translate-y-1/2 bg-white h-[1.5rem] w-[1.5rem] rounded-full"
-        initial={{ left: theme === "light" ? 2 : "calc(100% - 1.5rem - 2px)" }}
+        className="theme-toggle__thumb"
+        initial={{
+          left:
+            theme === "light"
+              ? "0.4rem"
+              : "calc(100% - 1.45rem - 0.4rem)",
+        }}
         animate={{
-          left: theme === "light" ? 2 : "calc(100% - 1.5rem - 2px)",
+          left:
+            theme === "light"
+              ? "0.4rem"
+              : "calc(100% - 1.45rem - 0.4rem)",
           transition: { duration: 0.3, ease: [0.18, 0.68, 0.43, 0.99] },
         }}
-        style={{ boxShadow: "0 1px 3px rgba(0, 0, 0, 0.1)" }}
       />
     </motion.button>
   );

--- a/apps/web/components/home/HeroSection.tsx
+++ b/apps/web/components/home/HeroSection.tsx
@@ -7,26 +7,33 @@ import { motion } from "motion/react";
  */
 const HeroSection = () => {
   return (
-    <section className="relative min-h-screen flex items-center justify-center overflow-hidden bg-white dark:bg-dark">
-      {/* 배경 (단색 또는 심플한 그라디언트) */}
-      <div className="absolute inset-0 bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-800 opacity-50" />
+    <section className="relative flex min-h-screen items-center justify-center overflow-hidden py-24">
+      {/* 배경 (감성 있는 그라디언트 + 글래스 라이트) */}
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_12%_18%,rgba(59,130,246,0.2),transparent_60%)] dark:bg-[radial-gradient(circle_at_15%_18%,rgba(59,130,246,0.35),transparent_65%)] opacity-80" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_85%_12%,rgba(56,189,248,0.18),transparent_62%)] dark:bg-[radial-gradient(circle_at_82%_15%,rgba(14,165,233,0.25),transparent_60%)] opacity-75" />
+        <div className="absolute inset-0 bg-gradient-to-b from-white/85 via-white/35 to-transparent dark:from-slate-950/82 dark:via-slate-950/35 dark:to-transparent" />
+      </div>
 
       {/* 텍스트 콘텐츠 (토스 스타일: 간결, 명확) */}
-      <div className="container mx-auto px-6 md:px-8 z-10">
-        <div className="max-w-3xl mx-auto text-center">
+      <div className="container relative z-10 mx-auto px-6 md:px-8">
+        <div className="mx-auto max-w-3xl text-center">
           <motion.h1
-            className="text-4xl md:text-6xl font-bold mb-5 leading-tight text-gray-900 dark:text-white"
+            className="text-balance text-4xl font-bold leading-tight text-gray-900 dark:text-white md:text-6xl"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, delay: 0.1, ease: "easeOut" }}
           >
             안녕하세요, 프론트엔드 개발자
             <br />
-            <span className="text-primary">김기원</span>입니다.
+            <span className="bg-gradient-to-r from-primary to-blue-400 dark:from-blue-300 dark:to-sky-400 bg-clip-text text-transparent">
+              김기원
+            </span>
+            입니다.
           </motion.h1>
 
           <motion.p
-            className="text-lg md:text-xl mb-10 text-gray-600 dark:text-gray-300 max-w-xl mx-auto"
+            className="mx-auto mb-10 max-w-2xl text-lg text-gray-600 dark:text-gray-300 md:text-xl"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, delay: 0.2, ease: "easeOut" }}
@@ -39,17 +46,17 @@ const HeroSection = () => {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, delay: 0.3, ease: "easeOut" }}
-            className="flex flex-col sm:flex-row justify-center gap-4"
+            className="flex flex-col items-center justify-center gap-4 sm:flex-row"
           >
             <a
               href="#about"
-              className="inline-block bg-primary hover:bg-primary/90 text-white font-semibold px-8 py-3 rounded-lg transition-colors text-base"
+              className="inline-flex items-center justify-center rounded-full bg-primary px-8 py-3 text-base font-semibold text-white shadow-[0_18px_40px_-20px_rgba(37,99,235,0.55)] transition-transform duration-300 hover:-translate-y-0.5 hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
             >
               더 알아보기
             </a>
             <a
               href="/contact"
-              className="inline-block bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-800 dark:text-white font-semibold px-8 py-3 rounded-lg transition-colors text-base"
+              className="inline-flex items-center justify-center rounded-full border border-gray-200/70 dark:border-slate-700/60 bg-white/80 dark:bg-slate-950/60 px-8 py-3 text-base font-semibold text-gray-800 dark:text-slate-200 backdrop-blur-md transition-transform duration-300 hover:-translate-y-0.5 hover:bg-white/90 dark:hover:bg-slate-900/60"
             >
               연락하기
             </a>
@@ -59,7 +66,7 @@ const HeroSection = () => {
 
       {/* 아래로 스크롤 안내 (심플하게) */}
       <motion.div
-        className="absolute bottom-8 left-1/2 transform -translate-x-1/2 text-gray-500 dark:text-gray-400"
+        className="absolute bottom-8 left-1/2 -translate-x-1/2 text-gray-500 dark:text-gray-400/80"
         initial={{ opacity: 0, y: -10 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{

--- a/apps/web/components/layout/TopNavbar.tsx
+++ b/apps/web/components/layout/TopNavbar.tsx
@@ -14,6 +14,7 @@ import {
   XMarkIcon,
   ArrowTopRightOnSquareIcon,
 } from "@heroicons/react/24/outline";
+import ThemeToggle from "../ThemeToggle";
 
 const TopNavbar = () => {
   const [isScrolled, setIsScrolled] = useState(false);
@@ -42,10 +43,8 @@ const TopNavbar = () => {
         initial={{ y: -100, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         transition={{ duration: 0.6, ease: "easeOut" }}
-        className={`sticky top-0 left-0 right-0 z-50 transition-all duration-300 ${
-          isScrolled
-            ? "bg-white/90 backdrop-blur-lg shadow-lg border-b border-gray-100"
-            : "bg-white/70 backdrop-blur-sm"
+        className={`sticky top-0 left-0 right-0 z-50 transition-all duration-500 ${
+          isScrolled ? "nav-surface nav-surface--scrolled" : "nav-surface"
         }`}
       >
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -55,7 +54,7 @@ const TopNavbar = () => {
               <Link href="/" className="flex items-center gap-3">
                 <div className="relative">
                   <motion.div
-                    className="w-10 h-10 bg-gradient-to-br from-blue-600 to-indigo-700 rounded-xl flex items-center justify-center shadow-lg"
+                    className="w-10 h-10 bg-gradient-to-br from-blue-600 to-indigo-700 dark:from-blue-500 dark:to-indigo-600 rounded-xl flex items-center justify-center shadow-lg shadow-blue-500/25 dark:shadow-blue-500/35"
                     whileHover={{ rotate: 10 }}
                     transition={{ type: "spring", stiffness: 300 }}
                   >
@@ -63,7 +62,7 @@ const TopNavbar = () => {
                   </motion.div>
                   {/* 글로우 효과 */}
                   <motion.div
-                    className="absolute inset-0 bg-blue-400 rounded-xl opacity-20 blur-lg"
+                    className="absolute inset-0 rounded-xl bg-blue-400/35 dark:bg-blue-500/35 blur-xl"
                     animate={{
                       scale: [1, 1.2, 1],
                       opacity: [0.2, 0.4, 0.2],
@@ -76,8 +75,8 @@ const TopNavbar = () => {
                   />
                 </div>
                 <div className="hidden sm:block">
-                  <h1 className="font-bold text-gray-900 text-lg">김기원</h1>
-                  <p className="text-xs text-gray-500 -mt-1">
+                  <h1 className="font-bold text-gray-900 dark:text-slate-100 text-lg">김기원</h1>
+                  <p className="text-xs text-gray-500 dark:text-slate-400 -mt-1">
                     Frontend Developer
                   </p>
                 </div>
@@ -86,7 +85,7 @@ const TopNavbar = () => {
 
             {/* 데스크톱 네비게이션 */}
             <div className="hidden md:flex items-center">
-              <div className="flex items-center space-x-2 bg-gray-50/80 rounded-full px-3 py-2.5 border border-gray-200/60">
+              <div className="flex items-center space-x-2 rounded-full px-3 py-2.5 border border-gray-200/60 dark:border-slate-700/50 bg-white/75 dark:bg-slate-950/60 backdrop-blur-lg shadow-[0_18px_40px_-24px_rgba(15,23,42,0.35)] dark:shadow-[0_28px_55px_-24px_rgba(2,6,23,0.78)] transition-colors duration-300">
                 {navigation.map((item, index) => {
                   const isActive = pathname === item.href;
                   const Icon = item.icon;
@@ -100,10 +99,10 @@ const TopNavbar = () => {
                     >
                       <Link
                         href={item.href}
-                        className={`relative flex items-center gap-3 px-5 py-3 rounded-full text-base font-medium transition-all duration-200 ${
+                        className={`relative flex items-center gap-3 px-5 py-3 rounded-full text-base font-medium transition-all duration-300 ${
                           isActive
-                            ? "text-white bg-blue-600 shadow-md"
-                            : "text-gray-700 hover:text-blue-600 hover:bg-white/70"
+                            ? "text-white bg-blue-600 dark:bg-blue-500/90 shadow-[0_16px_40px_-20px_rgba(59,130,246,0.6)]"
+                            : "text-gray-700 dark:text-slate-200 hover:text-blue-600 dark:hover:text-blue-300 hover:bg-white/70 dark:hover:bg-slate-900/50"
                         }`}
                       >
                         <Icon className="w-5 h-5" />
@@ -111,7 +110,7 @@ const TopNavbar = () => {
                         {isActive && (
                           <motion.div
                             layoutId="activeTab"
-                            className="absolute inset-0 bg-blue-600 rounded-full -z-10"
+                            className="absolute inset-0 bg-blue-600 dark:bg-blue-500 rounded-full -z-10"
                             transition={{
                               type: "spring",
                               bounce: 0.2,
@@ -128,12 +127,21 @@ const TopNavbar = () => {
 
             {/* 우측 버튼들 */}
             <div className="flex items-center gap-3">
+              <motion.div
+                initial={{ opacity: 0, y: -10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.2 }}
+                className="flex-shrink-0"
+              >
+                <ThemeToggle />
+              </motion.div>
+
               {/* GitHub 링크 */}
               <motion.a
                 href="https://github.com/milliwonkim"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="hidden sm:flex items-center justify-center w-10 h-10 text-gray-600 hover:text-gray-900 rounded-full hover:bg-gray-100 transition-colors"
+                className="hidden sm:flex items-center justify-center w-10 h-10 rounded-full text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-slate-800/70 transition-colors border border-gray-200/60 dark:border-slate-700/60 bg-white/70 dark:bg-slate-950/60 backdrop-blur-lg shadow-[0_16px_32px_-18px_rgba(15,23,42,0.35)] dark:shadow-[0_26px_44px_-18px_rgba(2,6,23,0.75)]"
                 whileHover={{ scale: 1.1 }}
                 whileTap={{ scale: 0.9 }}
               >
@@ -153,7 +161,7 @@ const TopNavbar = () => {
               >
                 <Link
                   href="/contact"
-                  className="hidden sm:flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-full text-sm font-medium hover:bg-blue-700 transition-colors shadow-lg shadow-blue-600/25"
+                  className="hidden sm:flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-full text-sm font-medium hover:bg-blue-700 transition-colors shadow-lg shadow-blue-600/25 dark:shadow-blue-500/35"
                 >
                   <EnvelopeIcon className="w-4 h-4" />
                   연락하기
@@ -163,7 +171,7 @@ const TopNavbar = () => {
               {/* 모바일 메뉴 버튼 */}
               <motion.button
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-                className="md:hidden flex items-center justify-center w-10 h-10 text-gray-600 hover:text-gray-900 rounded-full hover:bg-gray-100 transition-colors"
+                className="md:hidden flex items-center justify-center w-10 h-10 text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white rounded-full hover:bg-gray-100 dark:hover:bg-slate-800/70 transition-colors border border-gray-200/60 dark:border-slate-700/60 bg-white/70 dark:bg-slate-950/60 backdrop-blur-lg"
                 whileTap={{ scale: 0.9 }}
               >
                 <motion.div
@@ -190,7 +198,7 @@ const TopNavbar = () => {
             animate={{ opacity: 1, height: "auto" }}
             exit={{ opacity: 0, height: 0 }}
             transition={{ duration: 0.3 }}
-            className="fixed top-20 left-0 right-0 z-40 bg-white/95 backdrop-blur-lg border-b border-gray-200 shadow-xl md:hidden"
+            className="fixed top-20 left-0 right-0 z-40 bg-white/95 dark:bg-slate-950/85 backdrop-blur-xl border-b border-gray-200/70 dark:border-slate-800/60 shadow-xl shadow-[0_24px_50px_-24px_rgba(15,23,42,0.35)] dark:shadow-[0_32px_65px_-28px_rgba(2,6,23,0.85)] md:hidden"
           >
             <div className="max-w-md mx-auto p-6 space-y-4">
               {navigation.map((item, index) => {
@@ -209,15 +217,15 @@ const TopNavbar = () => {
                       onClick={() => setIsMobileMenuOpen(false)}
                       className={`flex items-center gap-3 p-3 rounded-xl transition-all duration-200 ${
                         isActive
-                          ? "bg-blue-600 text-white shadow-lg"
-                          : "text-gray-700 hover:bg-gray-50"
+                          ? "bg-blue-600 dark:bg-blue-500/85 text-white shadow-lg"
+                          : "text-gray-700 dark:text-slate-200 hover:bg-gray-50 dark:hover:bg-slate-900/60"
                       }`}
                     >
                       <Icon className="w-5 h-5" />
                       <span className="font-medium">{item.name}</span>
                       {isActive && (
                         <motion.div
-                          className="ml-auto w-2 h-2 bg-white rounded-full"
+                          className="ml-auto w-2 h-2 bg-white dark:bg-slate-200 rounded-full"
                           initial={{ scale: 0 }}
                           animate={{ scale: 1 }}
                           transition={{ delay: 0.2 }}
@@ -229,12 +237,12 @@ const TopNavbar = () => {
               })}
 
               {/* 모바일 액션 버튼들 */}
-              <div className="pt-4 border-t border-gray-200 space-y-3">
+              <div className="pt-4 border-t border-gray-200/70 dark:border-slate-800/60 space-y-3">
                 <motion.a
                   href="https://github.com/milliwonkim"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center gap-3 p-3 text-gray-700 hover:bg-gray-50 rounded-xl transition-colors"
+                  className="flex items-center gap-3 p-3 text-gray-700 dark:text-slate-200 hover:bg-gray-50 dark:hover:bg-slate-900/60 rounded-xl transition-colors"
                   initial={{ opacity: 0, x: -20 }}
                   animate={{ opacity: 1, x: 0 }}
                   transition={{ delay: 0.5 }}
@@ -258,7 +266,7 @@ const TopNavbar = () => {
                   <Link
                     href="/contact"
                     onClick={() => setIsMobileMenuOpen(false)}
-                    className="flex items-center justify-center gap-2 p-3 bg-blue-600 text-white rounded-xl font-medium hover:bg-blue-700 transition-colors"
+                    className="flex items-center justify-center gap-2 p-3 bg-blue-600 dark:bg-blue-500/85 text-white rounded-xl font-medium hover:bg-blue-700 dark:hover:bg-blue-500 transition-colors shadow-[0_16px_34px_-20px_rgba(37,99,235,0.55)] dark:shadow-[0_22px_40px_-18px_rgba(37,99,235,0.7)]"
                   >
                     <EnvelopeIcon className="w-5 h-5" />
                     연락하기
@@ -278,7 +286,7 @@ const TopNavbar = () => {
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
-            className="fixed inset-0 bg-black/20 backdrop-blur-sm z-30 md:hidden"
+            className="fixed inset-0 bg-black/20 dark:bg-black/40 backdrop-blur-sm z-30 md:hidden"
             onClick={() => setIsMobileMenuOpen(false)}
           />
         )}

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: ["class", '[data-theme="dark"]'],
   content: [
     "./app/**/*.{js,ts,jsx,tsx}",
     "./pages/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
## Summary
- expand the global theme surface/gradient system and update Tailwind to honor the `data-theme="dark"` attribute for consistent palette swapping
- polish the header experience with glassmorphism, responsive dark-mode variants, and embed the refreshed theme toggle
- refresh the hero section and toggle component styling to better showcase the distinct light and dark modes

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cd126a78d483228d25034cb3af555c