### PR TITLE
Restore Notion blog integration with theme-aware UI

### DIFF
--- a/apps/web/app/blog/[id]/page.tsx
+++ b/apps/web/app/blog/[id]/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
 import dynamic from "next/dynamic";
+import { useTheme } from "@repo/ui";
 import { getCategoryColor } from "../../../utils/categoryColors";
 
 interface NotionBlock {
@@ -33,53 +35,75 @@ const MonacoEditor = dynamic(() => import("@monaco-editor/react"), {
 function renderBlock(
   block: NotionBlock,
   idx: number,
-  allBlocks: NotionBlock[]
+  allBlocks: NotionBlock[],
+  monacoTheme: "vs-dark" | "vs-light"
 ) {
   switch (block.type) {
     case "heading_1":
       return (
-        <h1 key={block.id} className="text-2xl font-bold mt-8 mb-3">
+        <h1
+          key={block.id}
+          className="mt-8 mb-3 text-2xl font-bold text-[color:var(--color-text-primary)]"
+        >
           {block.text}
         </h1>
       );
     case "heading_2":
       return (
-        <h2 key={block.id} className="text-xl font-semibold mt-6 mb-2">
+        <h2
+          key={block.id}
+          className="mt-6 mb-2 text-xl font-semibold text-[color:var(--color-text-primary)]"
+        >
           {block.text}
         </h2>
       );
     case "heading_3":
       return (
-        <h3 key={block.id} className="text-lg font-medium mt-4 mb-2">
+        <h3
+          key={block.id}
+          className="mt-4 mb-2 text-lg font-medium text-[color:var(--color-text-primary)]"
+        >
           {block.text}
         </h3>
       );
     case "bulleted_list_item":
       return (
-        <li key={block.id} className="list-disc ml-6 mb-1">
+        <li
+          key={block.id}
+          className="mb-1 ml-6 list-disc text-[color:var(--color-text-primary)]"
+        >
           {block.text}
         </li>
       );
     case "numbered_list_item":
       return (
-        <li key={block.id} className="list-decimal ml-6 mb-1">
+        <li
+          key={block.id}
+          className="mb-1 ml-6 list-decimal text-[color:var(--color-text-primary)]"
+        >
           {block.text}
         </li>
       );
     case "paragraph":
       return (
-        <p key={block.id} className="mb-3 leading-relaxed">
+        <p
+          key={block.id}
+          className="mb-3 leading-relaxed text-[color:var(--color-text-primary)]"
+        >
           {block.text}
         </p>
       );
     case "code":
       return (
-        <div key={block.id} className="my-4">
+        <div
+          key={block.id}
+          className="my-4 overflow-hidden rounded-2xl border border-[color:var(--color-card-border)] bg-[color:var(--color-card-background)]/70 shadow-[0_18px_42px_var(--color-card-shadow)]"
+        >
           <MonacoEditor
             height="600px"
             defaultLanguage={block.language || "plaintext"}
             value={block.text || ""}
-            theme="vs-dark"
+            theme={monacoTheme}
             options={{
               readOnly: true,
               minimap: { enabled: false },
@@ -87,22 +111,25 @@ function renderBlock(
               scrollBeyondLastLine: false,
             }}
           />
-          <div className="text-xs text-gray-400 mt-1 text-right">
+          <div className="mt-1 px-3 pb-3 text-right text-xs text-[color:var(--color-text-tertiary)]">
             {block.language}
           </div>
         </div>
       );
     case "image":
       return (
-        <figure key={block.id} className="my-6 flex flex-col items-center">
+        <figure
+          key={block.id}
+          className="my-6 flex flex-col items-center gap-3 rounded-2xl border border-[color:var(--color-card-border)] bg-[color:var(--color-card-background)]/70 p-4 shadow-[0_18px_42px_var(--color-card-shadow)]"
+        >
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={block.url}
             alt={block.caption || "이미지"}
-            className="rounded max-w-full h-auto shadow"
+            className="h-auto w-full max-w-3xl rounded-xl border border-[color:var(--color-card-border)] object-cover"
           />
           {block.caption && (
-            <figcaption className="text-xs text-gray-500 mt-2 text-center">
+            <figcaption className="text-center text-xs text-[color:var(--color-text-tertiary)]">
               {block.caption}
             </figcaption>
           )}
@@ -112,7 +139,7 @@ function renderBlock(
       return (
         <hr
           key={block.id}
-          className="my-8 border-t border-gray-300 dark:border-gray-600"
+          className="my-8 border-t border-[color:var(--color-border-normal)]"
         />
       );
     case "table": {
@@ -131,13 +158,16 @@ function renderBlock(
       return (
         <table
           key={block.id}
-          className="my-8 border border-gray-300 dark:border-gray-600 w-full text-sm"
+          className="my-8 w-full overflow-hidden rounded-xl border border-[color:var(--color-border-normal)] text-sm"
         >
           <tbody>
             {rows.map((row) => (
               <tr key={row.id}>
                 {row.cells?.map((cell, ci) => (
-                  <td key={ci} className="border px-3 py-2">
+                  <td
+                    key={ci}
+                    className="border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/60 px-3 py-2 text-[color:var(--color-text-primary)]"
+                  >
                     {cell}
                   </td>
                 ))}
@@ -154,17 +184,17 @@ function renderBlock(
 
 function BlogDetailSkeleton() {
   return (
-    <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+    <div className="mx-auto max-w-2xl px-4 py-10 sm:px-6 lg:px-8">
       <div className="animate-pulse">
-        <div className="h-10 w-2/3 bg-gray-400  rounded mb-4" />
-        <div className="h-4 w-24 bg-gray-300  rounded mb-6" />
-        <div className="space-y-3 mb-8">
-          <div className="h-4 w-full bg-gray-400 rounded" />
-          <div className="h-4 w-5/6 bg-gray-400  rounded" />
-          <div className="h-4 w-4/6 bg-gray-400  rounded" />
-          <div className="h-4 w-3/6 bg-gray-300  rounded" />
+        <div className="mb-4 h-10 w-2/3 rounded bg-[color:var(--color-border-normal)]/40" />
+        <div className="mb-6 h-4 w-24 rounded bg-[color:var(--color-border-normal)]/30" />
+        <div className="mb-8 space-y-3">
+          <div className="h-4 w-full rounded bg-[color:var(--color-border-normal)]/35" />
+          <div className="h-4 w-5/6 rounded bg-[color:var(--color-border-normal)]/35" />
+          <div className="h-4 w-4/6 rounded bg-[color:var(--color-border-normal)]/30" />
+          <div className="h-4 w-3/6 rounded bg-[color:var(--color-border-normal)]/25" />
         </div>
-        <div className="h-10 w-32 bg-gray-300  rounded" />
+        <div className="h-10 w-32 rounded bg-[color:var(--color-border-normal)]/30" />
       </div>
     </div>
   );
@@ -175,6 +205,12 @@ export default function BlogDetailPage() {
   const [post, setPost] = useState<NotionPostDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { resolvedTheme } = useTheme();
+
+  const monacoTheme = useMemo<"vs-dark" | "vs-light">(
+    () => (resolvedTheme === "dark" ? "vs-dark" : "vs-light"),
+    [resolvedTheme]
+  );
 
   useEffect(() => {
     if (!id) return;
@@ -196,7 +232,7 @@ export default function BlogDetailPage() {
 
   // 리스트 블록 그룹핑
   const blocks = post.blocks;
-  const content: React.ReactNode[] = [];
+  const content: ReactNode[] = [];
   let listBuffer: NotionBlock[] = [];
   let lastListType: string | null = null;
   const categoryColor = post.category ? getCategoryColor(post.category) : null;
@@ -211,8 +247,11 @@ export default function BlogDetailPage() {
       } else {
         // 타입이 바뀌면 이전 리스트 렌더
         content.push(
-          <ul key={listBuffer[0]?.id + "-ul"} className="mb-3">
-            {listBuffer.map((b) => renderBlock(b, idx, blocks))}
+          <ul
+            key={listBuffer[0]?.id + "-ul"}
+            className="mb-3 space-y-1 text-[color:var(--color-text-primary)]"
+          >
+            {listBuffer.map((b) => renderBlock(b, idx, blocks, monacoTheme))}
           </ul>
         );
         listBuffer = [block];
@@ -221,32 +260,38 @@ export default function BlogDetailPage() {
     } else {
       if (listBuffer.length > 0) {
         content.push(
-          <ul key={listBuffer[0]?.id + "-ul"} className="mb-3">
-            {listBuffer.map((b) => renderBlock(b, idx, blocks))}
+          <ul
+            key={listBuffer[0]?.id + "-ul"}
+            className="mb-3 space-y-1 text-[color:var(--color-text-primary)]"
+          >
+            {listBuffer.map((b) => renderBlock(b, idx, blocks, monacoTheme))}
           </ul>
         );
         listBuffer = [];
         lastListType = null;
       }
-      content.push(renderBlock(block, idx, blocks));
+      content.push(renderBlock(block, idx, blocks, monacoTheme));
     }
   });
   if (listBuffer.length > 0) {
     content.push(
-      <ul key={listBuffer[0]?.id + "-ul"} className="mb-3">
+      <ul
+        key={listBuffer[0]?.id + "-ul"}
+        className="mb-3 space-y-1 text-[color:var(--color-text-primary)]"
+      >
         {listBuffer
           .filter(Boolean)
-          .map((b) => renderBlock(b, blocks.length, blocks))}
+          .map((b) => renderBlock(b, blocks.length, blocks, monacoTheme))}
       </ul>
     );
   }
 
   return (
-    <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
-      <h1 className="text-3xl font-bold mb-4 text-[var(--color-text-primary)]">
+    <div className="mx-auto max-w-2xl px-4 py-10 sm:px-6 lg:px-8">
+      <h1 className="mb-4 text-3xl font-bold text-[color:var(--color-text-primary)]">
         {post.title}
       </h1>
-      <div className="flex items-center text-xs text-[var(--color-text-secondary)] mb-6 gap-2">
+      <div className="mb-6 flex items-center gap-2 text-xs text-[color:var(--color-text-secondary)]">
         {post.category && categoryColor && (
           <span
             className={`px-2 py-1 rounded-full font-medium ${categoryColor.bg} ${categoryColor.text}`}
@@ -262,17 +307,47 @@ export default function BlogDetailPage() {
           })}
         </span>
       </div>
-      <div className="prose prose-neutral dark:prose-invert mb-8">
-        <p>{post.description}</p>
+      <div className="mb-8 space-y-4 text-[color:var(--color-text-primary)]">
+        <p className="text-[color:var(--color-text-secondary)]">
+          {post.description}
+        </p>
         {content}
       </div>
       <a
         href={post.url}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-block px-4 py-2 bg-[var(--color-primary)] text-white rounded hover:bg-[var(--color-primary-hover)] transition-colors"
+        className="inline-flex items-center gap-2 rounded-full bg-[color:var(--color-primary)] px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-[color:var(--color-primary-hover)]"
       >
         노션에서 원문 보기
+        <svg
+          className="h-4 w-4"
+          viewBox="0 0 20 20"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M11.25 3.75H16.25V8.75"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M8.75 11.25L16.25 3.75"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M8.75 3.75H5.75C4.64543 3.75 3.75 4.64543 3.75 5.75V14.25C3.75 15.3546 4.64543 16.25 5.75 16.25H14.25C15.3546 16.25 16.25 15.3546 16.25 14.25V11.5"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
       </a>
     </div>
   );

--- a/apps/web/components/ThemeToggle.tsx
+++ b/apps/web/components/ThemeToggle.tsx
@@ -2,55 +2,45 @@
 
 import { useEffect, useState } from "react";
 import { motion } from "motion/react";
+import { useThemeToggle } from "@repo/ui";
 
 /**
  * @description 토스 스타일의 라이트/다크 테마 토글 컴포넌트
  * @returns 테마 전환 토글 버튼 UI
  */
 export default function ThemeToggle() {
-  const [theme, setTheme] = useState<"light" | "dark">("light");
+  const { theme, resolvedTheme, toggleTheme } = useThemeToggle();
   const [mounted, setMounted] = useState(false);
 
-  // 초기 테마 설정 및 마운트 상태 관리
   useEffect(() => {
     setMounted(true);
-
-    // 로컬 스토리지에서 테마 불러오기 또는 시스템 설정 확인
-    const savedTheme = localStorage.getItem("theme");
-    const prefersDark = window.matchMedia(
-      "(prefers-color-scheme: dark)"
-    ).matches;
-
-    // 저장된 테마가 있으면 사용, 없으면 시스템 설정 따르기
-    const initialTheme = savedTheme || (prefersDark ? "dark" : "light");
-    document.documentElement.setAttribute("data-theme", initialTheme);
-    setTheme(initialTheme as "light" | "dark");
   }, []);
 
-  /**
-   * 테마 전환 함수
-   */
-  const toggleTheme = () => {
-    const newTheme = theme === "light" ? "dark" : "light";
-    setTheme(newTheme);
-    document.documentElement.setAttribute("data-theme", newTheme);
-    localStorage.setItem("theme", newTheme);
-  };
-
-  // 서버 렌더링 시 불일치 방지
   if (!mounted) {
     return (
-      <div className="w-[3.25rem] h-[1.75rem] rounded-full bg-gray-200 opacity-80" />
+      <div className="h-[1.75rem] w-[3.25rem] rounded-full bg-[color:var(--color-card-border)]/50" />
     );
   }
+
+  const isLight = resolvedTheme === "light";
+  const labelTheme =
+    theme === "system"
+      ? `시스템 (${isLight ? "라이트" : "다크"})`
+      : theme === "light"
+        ? "라이트"
+        : "다크";
+
+  const thumbPosition = isLight
+    ? "0.4rem"
+    : "calc(100% - 1.45rem - 0.4rem)";
 
   return (
     <motion.button
       type="button"
       className="theme-toggle"
       onClick={toggleTheme}
-      aria-label={`테마 전환: 현재 ${theme === "light" ? "라이트" : "다크"} 모드`}
-      aria-pressed={theme === "dark"}
+      aria-label={`테마 전환: 현재 ${labelTheme} 모드`}
+      aria-pressed={!isLight}
       whileTap={{ scale: 0.95 }}
     >
       <span className="sun-icon">
@@ -93,19 +83,9 @@ export default function ThemeToggle() {
       </span>
       <motion.span
         className="theme-toggle__thumb"
-        initial={{
-          left:
-            theme === "light"
-              ? "0.4rem"
-              : "calc(100% - 1.45rem - 0.4rem)",
-        }}
-        animate={{
-          left:
-            theme === "light"
-              ? "0.4rem"
-              : "calc(100% - 1.45rem - 0.4rem)",
-          transition: { duration: 0.3, ease: [0.18, 0.68, 0.43, 0.99] },
-        }}
+        initial={false}
+        animate={{ left: thumbPosition }}
+        transition={{ duration: 0.3, ease: [0.18, 0.68, 0.43, 0.99] }}
       />
     </motion.button>
   );

--- a/apps/web/components/blog/BlogCard.tsx
+++ b/apps/web/components/blog/BlogCard.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { motion } from "motion/react";
 import type { NotionPost } from "../../app/blog/page";
 import { getCategoryColor } from "../../utils/categoryColors";
@@ -11,30 +12,35 @@ export default function BlogCard({ post, index = 0 }: BlogCardProps) {
   const categoryColor = post.category
     ? getCategoryColor(post.category)
     : null;
+
   return (
-    <a href={post.url} className="block h-full">
+    <Link
+      href={`/blog/${post.id}`}
+      className="group block h-full"
+      aria-label={`${post.title} 블로그 글 상세 보기`}
+    >
       <motion.div
         key={post.id}
-        className="group relative h-full bg-white/60 backdrop-blur-sm rounded-2xl overflow-hidden border border-white/60 hover:border-[var(--color-primary)]/30 transition-all duration-300 shadow-lg hover:shadow-2xl cursor-pointer hover:scale-105"
+        className="relative flex h-full flex-col overflow-hidden rounded-2xl border border-[color:var(--color-card-border)] bg-[color:var(--color-card-background)]/90 backdrop-blur-sm shadow-[0_18px_42px_var(--color-card-shadow)] transition-all duration-300 hover:-translate-y-1 hover:scale-[1.02] hover:border-[color:var(--color-primary)]/35 hover:shadow-[0_26px_56px_var(--color-card-shadow-hover)]"
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5, delay: index * 0.1, ease: "easeOut" }}
       >
-        <div className="p-6 h-full flex flex-col">
+        <div className="flex h-full flex-col p-6">
           {/* 헤더 섹션 */}
-          <div className="flex flex-col mb-4">
+          <div className="mb-4 flex flex-col">
             {post.category && categoryColor && (
               <span
-                className={`inline-flex w-fit px-3 py-1 rounded-full text-xs font-medium mb-2 ${categoryColor.bg} ${categoryColor.text}`}
+                className={`inline-flex w-fit px-3 py-1 text-xs font-medium ${categoryColor.bg} ${categoryColor.text} ${categoryColor.border} rounded-full border mb-2 shadow-sm`}
               >
                 {post.category}
               </span>
             )}
-            <div className="flex items-start justify-between mb-3">
-              <h2 className="font-bold text-lg text-[var(--color-text-primary)] group-hover:text-[var(--color-primary)] transition-colors leading-tight line-clamp-2 flex-1 mr-2">
+            <div className="mb-3 flex items-start justify-between gap-2">
+              <h2 className="mr-2 flex-1 text-lg font-bold leading-tight text-[color:var(--color-text-primary)] transition-colors group-hover:text-[color:var(--color-primary)]">
                 {post.title}
               </h2>
-              <span className="text-xs font-medium px-3 py-1 bg-[var(--color-primary)]/10 text-[var(--color-primary)] rounded-full whitespace-nowrap">
+              <span className="whitespace-nowrap rounded-full bg-[color:var(--color-primary)]/12 px-3 py-1 text-xs font-medium text-[color:var(--color-primary)]">
                 {new Date(post.createdAt).toLocaleDateString("ko-KR", {
                   year: "numeric",
                   month: "short",
@@ -45,35 +51,67 @@ export default function BlogCard({ post, index = 0 }: BlogCardProps) {
           </div>
 
           {/* 설명 섹션 - flex-1로 남은 공간 차지 */}
-          <div className="flex-1 flex flex-col">
-            <p className="text-[var(--color-text-secondary)] text-sm leading-relaxed line-clamp-3 mb-6 flex-1">
+          <div className="flex flex-1 flex-col">
+            <p className="mb-6 flex-1 text-sm leading-relaxed text-[color:var(--color-text-secondary)] line-clamp-3">
               {post.description || "블로그 글의 미리보기 내용입니다."}
             </p>
           </div>
 
           {/* 하단 액션 섹션 - 항상 하단에 고정 */}
-          <div className="mt-auto">
-            <div className="flex items-center justify-between">
-              <span className="inline-flex items-center text-sm font-semibold text-[var(--color-primary)] group-hover:text-[var(--color-primary-hover)] transition-colors">
-                자세히 보기
-                <svg
-                  className="w-4 h-4 ml-2 transform translate-x-0 group-hover:translate-x-1 transition-transform duration-200 ease-in-out"
-                  fill="none"
+          <div className="mt-auto flex items-center justify-between">
+            <span className="inline-flex items-center text-sm font-semibold text-[color:var(--color-primary)] transition-colors group-hover:text-[color:var(--color-primary-hover)]">
+              자세히 보기
+              <svg
+                className="ml-2 h-4 w-4 translate-x-0 transition-transform duration-200 ease-in-out group-hover:translate-x-1"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M17 8l4 4m0 0l-4 4m4-4H3"
+                />
+              </svg>
+            </span>
+            <span
+              className="inline-flex items-center gap-1 text-xs font-medium text-[color:var(--color-text-tertiary)]"
+              title="노션 데이터로 작성된 글"
+            >
+              Notion 기반
+              <svg
+                className="h-3.5 w-3.5"
+                viewBox="0 0 20 20"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M11.25 3.75H16.25V8.75"
                   stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M17 8l4 4m0 0l-4 4m4-4H3"
-                  />
-                </svg>
-              </span>
-            </div>
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M8.75 11.25L16.25 3.75"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M8.75 3.75H5.75C4.64543 3.75 3.75 4.64543 3.75 5.75V14.25C3.75 15.3546 4.64543 16.25 5.75 16.25H14.25C15.3546 16.25 16.25 15.3546 16.25 14.25V11.5"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </span>
           </div>
         </div>
       </motion.div>
-    </a>
+    </Link>
   );
 }

--- a/apps/web/components/projects/ProjectCard.tsx
+++ b/apps/web/components/projects/ProjectCard.tsx
@@ -96,7 +96,9 @@ export default function ProjectCard({ project, index = 0 }: ProjectCardProps) {
             </svg>
           </div>
         ) : (
-          <span className="text-sm text-gray-400 font-medium">링크 준비중</span>
+          <span className="text-sm font-medium text-[color:var(--color-text-tertiary)]">
+            링크 준비중
+          </span>
         )}
 
         {/* 새창 아이콘 표시 */}


### PR DESCRIPTION
## Summary
- make the blog detail renderer theme-aware, including Monaco editor theme switches and typography using shared color tokens sourced from Notion content
- route blog cards through internal pages with revamped glassmorphism styling and a Notion origin badge while keeping metadata presentation consistent
- connect the site header theme toggle to the shared ThemeProvider and align auxiliary components with the dark/light palette

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ce589bdb188322adcbe26cb38b61b5