### PR TITLE
Render Notion overview properties

### DIFF
--- a/apps/web/app/api/overview/route.ts
+++ b/apps/web/app/api/overview/route.ts
@@ -13,10 +13,39 @@ export interface NotionOverviewBlock {
   children?: NotionOverviewBlock[];
 }
 
+export interface NotionOverviewTag {
+  id: string;
+  name: string;
+  color?: string;
+}
+
+export interface NotionOverviewPerson {
+  id: string;
+  name: string;
+  avatarUrl?: string;
+}
+
+export interface NotionOverviewFile {
+  name: string;
+  url: string;
+}
+
+export interface NotionOverviewProperty {
+  id: string;
+  name: string;
+  type: string;
+  value: string;
+  isEmpty: boolean;
+  tags?: NotionOverviewTag[];
+  people?: NotionOverviewPerson[];
+  files?: NotionOverviewFile[];
+}
+
 export interface NotionOverviewResponse {
   title: string;
   lastEditedTime: string;
   url: string;
+  properties: NotionOverviewProperty[];
   blocks: NotionOverviewBlock[];
 }
 
@@ -24,17 +53,229 @@ const notion = new Client({ auth: process.env.NOTION_API_KEY });
 
 const FALLBACK_OVERVIEW_PAGE_ID = "2749a57291028051aafcf7982552da08";
 
-function normalizeNotionId(id: string): string {
-  const cleaned = id.replace(/-/g, "").replace(/\?.*/, "");
-  if (cleaned.length !== 32) return id;
-  return `${cleaned.slice(0, 8)}-${cleaned.slice(8, 12)}-${cleaned.slice(12, 16)}-${cleaned.slice(16, 20)}-${cleaned.slice(20)}`;
+function normalizeNotionId(rawId: string): string {
+  const trimmed = rawId.trim();
+  if (!trimmed) return "";
+
+  const matches = trimmed
+    .replace(/-/g, "")
+    .match(/[0-9a-f]{32}/i);
+
+  if (!matches) {
+    return "";
+  }
+
+  const id = matches[0].toLowerCase();
+
+  return `${id.slice(0, 8)}-${id.slice(8, 12)}-${id.slice(12, 16)}-${id.slice(16, 20)}-${id.slice(20)}`;
 }
 
 function extractPlainText(property: any): string {
   if (!property) return "";
-  const richText = property.rich_text;
+  const richText = property.rich_text ?? property.title;
   if (!Array.isArray(richText)) return "";
   return richText.map((text: any) => text.plain_text).join("").trim();
+}
+
+function formatDate(value?: string | null): string {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+}
+
+function formatDateRange(date: any): string {
+  if (!date) return "";
+  const start = formatDate(date.start);
+  const end = formatDate(date.end);
+  if (start && end) {
+    return `${start} ~ ${end}`;
+  }
+  return start || end;
+}
+
+function transformProperty(
+  name: string,
+  property: any
+): NotionOverviewProperty | null {
+  if (!property || !property.type || property.type === "title") {
+    return null;
+  }
+
+  const base: NotionOverviewProperty = {
+    id: property.id,
+    name,
+    type: property.type,
+    value: "",
+    isEmpty: true,
+  };
+
+  switch (property.type) {
+    case "rich_text":
+      base.value = extractPlainText(property);
+      break;
+    case "select":
+      base.value = property.select?.name?.trim() ?? "";
+      if (property.select) {
+        base.tags = [
+          {
+            id: property.select.id,
+            name: property.select.name,
+            color: property.select.color,
+          },
+        ];
+      }
+      break;
+    case "multi_select":
+      base.tags = (property.multi_select ?? []).map((option: any) => ({
+        id: option.id,
+        name: option.name,
+        color: option.color,
+      }));
+      base.value = base.tags.map((tag) => tag.name).join(", ");
+      break;
+    case "status":
+      base.value = property.status?.name?.trim() ?? "";
+      if (property.status) {
+        base.tags = [
+          {
+            id: property.status.id,
+            name: property.status.name,
+            color: property.status.color,
+          },
+        ];
+      }
+      break;
+    case "date":
+      base.value = formatDateRange(property.date);
+      break;
+    case "checkbox":
+      base.value = property.checkbox ? "예" : "아니오";
+      break;
+    case "number":
+      base.value =
+        typeof property.number === "number" ? String(property.number) : "";
+      break;
+    case "url":
+      base.value = property.url?.trim() ?? "";
+      break;
+    case "email":
+      base.value = property.email?.trim() ?? "";
+      break;
+    case "phone_number":
+      base.value = property.phone_number?.trim() ?? "";
+      break;
+    case "people":
+      base.people = (property.people ?? []).map((person: any) => ({
+        id: person.id,
+        name: person.name ?? person?.person?.email ?? "이름 없음",
+        avatarUrl: person.avatar_url ?? undefined,
+      }));
+      base.value = base.people.map((person) => person.name).join(", ");
+      break;
+    case "files":
+      base.files = (property.files ?? []).map((file: any) => {
+        const url =
+          file.file?.url ?? file.external?.url ?? file.name ?? "";
+        return {
+          name: file.name ?? url,
+          url,
+        };
+      });
+      base.value = base.files.map((file) => file.name).join(", ");
+      break;
+    case "relation":
+      base.value = (property.relation ?? [])
+        .map((relation: any) => relation.id)
+        .join(", ");
+      break;
+    case "formula":
+      switch (property.formula?.type) {
+        case "string":
+          base.value = property.formula.string ?? "";
+          break;
+        case "number":
+          base.value =
+            typeof property.formula.number === "number"
+              ? String(property.formula.number)
+              : "";
+          break;
+        case "boolean":
+          base.value = property.formula.boolean ? "예" : "아니오";
+          break;
+        case "date":
+          base.value = formatDateRange(property.formula.date);
+          break;
+        default:
+          base.value = "";
+      }
+      break;
+    case "rollup":
+      if (property.rollup?.type === "array") {
+        const arrayValues = property.rollup.array
+          .map((item: any) => {
+            if (item.type === "title") {
+              return extractPlainText(item);
+            }
+            if (item.type === "rich_text") {
+              return extractPlainText(item);
+            }
+            if (item.type === "people") {
+              return (item.people ?? [])
+                .map((person: any) => person.name ?? "")
+                .filter(Boolean)
+                .join(", ");
+            }
+            if (item[item.type]) {
+              return String(item[item.type]);
+            }
+            return "";
+          })
+          .filter((value: string) => value.trim().length > 0);
+        base.value = arrayValues.join(", ");
+      } else if (property.rollup?.type === "number") {
+        base.value =
+          typeof property.rollup.number === "number"
+            ? String(property.rollup.number)
+            : "";
+      } else if (property.rollup?.type === "date") {
+        base.value = formatDateRange(property.rollup.date);
+      } else if (property.rollup?.type === "incomplete") {
+        base.value = "";
+      }
+      break;
+    default:
+      if (property[property.type]) {
+        base.value = String(property[property.type]);
+      }
+      break;
+  }
+
+  base.isEmpty =
+    !base.value.trim() &&
+    (!base.tags || base.tags.length === 0) &&
+    (!base.people || base.people.length === 0) &&
+    (!base.files || base.files.length === 0);
+
+  return base;
+}
+
+function extractProperties(
+  properties: Record<string, any> | undefined
+): NotionOverviewProperty[] {
+  if (!properties) return [];
+
+  const entries = Object.entries(properties)
+    .map(([name, property]) => transformProperty(name, property))
+    .filter((property): property is NotionOverviewProperty => Boolean(property));
+
+  return entries;
 }
 
 async function fetchBlockChildren(blockId: string): Promise<any[]> {
@@ -128,13 +369,16 @@ export async function GET() {
     const pageId = normalizeNotionId(rawPageId);
 
     if (!pageId) {
-      throw new Error("NOTION_OVERVIEW_PAGE_ID is not set");
+      throw new Error(
+        "NOTION_OVERVIEW_PAGE_ID is not set or is invalid. Provide a Notion page ID or share URL."
+      );
     }
 
     const page = (await notion.pages.retrieve({ page_id: pageId })) as any;
     const title = extractTitle(page.properties ?? {});
     const url = page.public_url || page.url || "";
     const lastEditedTime = page.last_edited_time ?? "";
+    const properties = extractProperties(page.properties ?? {});
 
     const rootBlocks = await fetchBlockChildren(pageId);
     const blocks = await transformBlocks(rootBlocks);
@@ -143,6 +387,7 @@ export async function GET() {
       title,
       url,
       lastEditedTime,
+      properties,
       blocks,
     };
 

--- a/apps/web/components/sections/OverviewSection.tsx
+++ b/apps/web/components/sections/OverviewSection.tsx
@@ -7,14 +7,156 @@ import { useQuery } from "@tanstack/react-query";
 
 import type {
   NotionOverviewBlock,
+  NotionOverviewProperty,
   NotionOverviewResponse,
+  NotionOverviewTag,
 } from "@/app/api/overview/route";
 import SectionContainer from "./SectionContainer";
 import SectionHeader from "./SectionHeader";
 
 const skeletonParagraphs = Array.from({ length: 4 });
+const propertySkeletons = Array.from({ length: 6 });
 
 type ListBlockType = "bulleted_list_item" | "numbered_list_item";
+
+const notionTagColorMap: Record<
+  NonNullable<NotionOverviewTag["color"]>,
+  { background: string; color: string }
+> = {
+  default: {
+    background: "rgba(148, 163, 184, 0.18)",
+    color: "var(--color-text-secondary)",
+  },
+  gray: {
+    background: "rgba(148, 163, 184, 0.18)",
+    color: "rgb(71, 85, 105)",
+  },
+  brown: {
+    background: "rgba(120, 53, 15, 0.18)",
+    color: "rgb(88, 28, 13)",
+  },
+  orange: {
+    background: "rgba(234, 88, 12, 0.18)",
+    color: "rgb(154, 52, 18)",
+  },
+  yellow: {
+    background: "rgba(202, 138, 4, 0.18)",
+    color: "rgb(133, 77, 14)",
+  },
+  green: {
+    background: "rgba(22, 163, 74, 0.2)",
+    color: "rgb(22, 101, 52)",
+  },
+  blue: {
+    background: "rgba(37, 99, 235, 0.18)",
+    color: "rgb(37, 99, 235)",
+  },
+  purple: {
+    background: "rgba(168, 85, 247, 0.18)",
+    color: "rgb(126, 34, 206)",
+  },
+  pink: {
+    background: "rgba(236, 72, 153, 0.18)",
+    color: "rgb(190, 24, 93)",
+  },
+  red: {
+    background: "rgba(239, 68, 68, 0.18)",
+    color: "rgb(185, 28, 28)",
+  },
+};
+
+function getTagStyles(tag: NotionOverviewTag) {
+  const fallback = {
+    background: "rgba(148, 163, 184, 0.16)",
+    color: "var(--color-text-secondary)",
+  };
+  if (!tag.color) return fallback;
+  return notionTagColorMap[tag.color] ?? fallback;
+}
+
+function renderPropertyValue(property: NotionOverviewProperty): ReactNode {
+  if (property.tags && property.tags.length > 0) {
+    return (
+      <div className="flex flex-wrap gap-2">
+        {property.tags.map((tag) => {
+          const style = getTagStyles(tag);
+          return (
+            <span
+              key={`${property.id}-${tag.id}`}
+              className="rounded-full border border-transparent px-3 py-1 text-xs font-medium"
+              style={{
+                background: style.background,
+                color: style.color,
+              }}
+            >
+              {tag.name}
+            </span>
+          );
+        })}
+      </div>
+    );
+  }
+
+  if (property.people && property.people.length > 0) {
+    return (
+      <div className="flex flex-wrap gap-2 text-sm text-[color:var(--color-text-secondary)]">
+        {property.people.map((person) => (
+          <span key={`${property.id}-${person.id}`}>{person.name}</span>
+        ))}
+      </div>
+    );
+  }
+
+  if (property.files && property.files.length > 0) {
+    return (
+      <ul className="space-y-2 text-sm">
+        {property.files.map((file) => (
+          <li key={`${property.id}-${file.url}`}>
+            <a
+              href={file.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[color:var(--color-primary)] underline-offset-4 hover:underline"
+            >
+              {file.name}
+            </a>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  if (property.type === "url" && property.value) {
+    return (
+      <a
+        href={property.value}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-[color:var(--color-primary)] underline-offset-4 hover:underline"
+      >
+        {property.value}
+      </a>
+    );
+  }
+
+  if (property.value) {
+    return (
+      <span className="text-sm text-[color:var(--color-text-secondary)]">
+        {property.value}
+      </span>
+    );
+  }
+
+  if (property.isEmpty) {
+    return (
+      <span className="text-sm italic text-[color:var(--color-text-tertiary)]">
+        비어 있음
+      </span>
+    );
+  }
+
+  return null;
+}
 
 function renderBlock(block: NotionOverviewBlock): ReactNode {
   switch (block.type) {
@@ -234,6 +376,26 @@ export default function OverviewSection() {
     [data]
   );
 
+  const renderedProperties = useMemo(() => {
+    if (!data?.properties?.length) {
+      return [];
+    }
+
+    return data.properties.map((property) => (
+      <div
+        key={property.id}
+        className="rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/70 px-4 py-3"
+      >
+        <dt className="text-xs font-medium uppercase tracking-[0.2em] text-[color:var(--color-text-tertiary)]">
+          {property.name}
+        </dt>
+        <dd className="mt-2 text-[color:var(--color-text-primary)]">
+          {renderPropertyValue(property)}
+        </dd>
+      </div>
+    ));
+  }, [data]);
+
   const lastUpdatedLabel = useMemo(() => {
     if (!data?.lastEditedTime) return "";
     const date = new Date(data.lastEditedTime);
@@ -301,15 +463,29 @@ export default function OverviewSection() {
 
       <div className="mt-10 rounded-3xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/85 p-8 shadow-lg shadow-[color:var(--color-card-shadow)]/40">
         {isPending && (
-          <div className="space-y-6">
-            <div className="h-5 w-40 rounded bg-[color:var(--color-border-normal)]/30" />
-            {skeletonParagraphs.map((_, index) => (
-              <div key={`overview-skeleton-${index}`} className="space-y-2">
-                <div className="h-4 w-full rounded bg-[color:var(--color-border-normal)]/20" />
-                <div className="h-4 w-5/6 rounded bg-[color:var(--color-border-normal)]/20" />
-                <div className="h-4 w-4/6 rounded bg-[color:var(--color-border-normal)]/15" />
-              </div>
-            ))}
+          <div className="space-y-10">
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+              {propertySkeletons.map((_, index) => (
+                <div
+                  key={`overview-property-skeleton-${index}`}
+                  className="h-24 rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-border-normal)]/10 px-4 py-3"
+                >
+                  <div className="h-3 w-24 rounded bg-[color:var(--color-border-normal)]/40" />
+                  <div className="mt-3 h-4 w-32 rounded bg-[color:var(--color-border-normal)]/30" />
+                </div>
+              ))}
+            </div>
+
+            <div className="space-y-6">
+              <div className="h-5 w-40 rounded bg-[color:var(--color-border-normal)]/30" />
+              {skeletonParagraphs.map((_, index) => (
+                <div key={`overview-skeleton-${index}`} className="space-y-2">
+                  <div className="h-4 w-full rounded bg-[color:var(--color-border-normal)]/20" />
+                  <div className="h-4 w-5/6 rounded bg-[color:var(--color-border-normal)]/20" />
+                  <div className="h-4 w-4/6 rounded bg-[color:var(--color-border-normal)]/15" />
+                </div>
+              ))}
+            </div>
           </div>
         )}
 
@@ -319,15 +495,24 @@ export default function OverviewSection() {
           </div>
         )}
 
-        {!isPending && !error && data && renderedBlocks.length === 0 && (
+        {!isPending && !error && data &&
+          renderedProperties.length === 0 &&
+          renderedBlocks.length === 0 && (
           <div className="rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/80 p-6 text-sm text-[color:var(--color-text-secondary)]">
             표시할 자기소개 블록이 없습니다. 노션 페이지에 내용을 추가하면 자동으로 반영됩니다.
           </div>
         )}
 
-        {!isPending && !error && renderedBlocks.length > 0 && (
-          <div className="space-y-6">
-            {renderedBlocks}
+        {!isPending && !error && (renderedProperties.length > 0 || renderedBlocks.length > 0) && (
+          <div className="space-y-8">
+            {renderedProperties.length > 0 && (
+              <dl className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                {renderedProperties}
+              </dl>
+            )}
+            {renderedBlocks.length > 0 && (
+              <div className="space-y-6">{renderedBlocks}</div>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- expose normalized Notion property metadata from the overview API so database fields are available alongside blocks
- format common Notion property types (dates, selects, multi-selects, rollups, files, etc.) into display-friendly values
- render the overview property grid with styled tags, loading skeletons, and updated empty states in the overview section

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cec23d74d0832287f99d162a42c735