### PR TITLE
Render Notion overview databases and adjust blog spacing

### DIFF
--- a/apps/web/app/api/overview/route.ts
+++ b/apps/web/app/api/overview/route.ts
@@ -4,6 +4,20 @@ import { Client } from "@notionhq/client";
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable turbo/no-undeclared-env-vars */
 
+export interface NotionOverviewDatabaseEntry {
+  id: string;
+  title: string;
+  url: string;
+  createdTime?: string;
+  lastEditedTime?: string;
+  properties: NotionOverviewProperty[];
+}
+
+export interface NotionOverviewDatabaseBlock {
+  title: string;
+  entries: NotionOverviewDatabaseEntry[];
+}
+
 export interface NotionOverviewBlock {
   id: string;
   type: string;
@@ -11,6 +25,7 @@ export interface NotionOverviewBlock {
   checked?: boolean;
   icon?: string;
   children?: NotionOverviewBlock[];
+  database?: NotionOverviewDatabaseBlock;
 }
 
 export interface NotionOverviewTag {
@@ -296,6 +311,30 @@ async function fetchBlockChildren(blockId: string): Promise<any[]> {
   return results;
 }
 
+async function fetchDatabaseEntries(databaseId: string): Promise<any[]> {
+  const results: any[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const response = await notion.databases.query({
+      database_id: databaseId,
+      page_size: 50,
+      start_cursor: cursor,
+    });
+
+    results.push(...response.results);
+    cursor = response.has_more ? response.next_cursor ?? undefined : undefined;
+  } while (cursor);
+
+  return results;
+}
+
+function getTimestamp(value?: string): number {
+  if (!value) return 0;
+  const timestamp = new Date(value).getTime();
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
 async function transformBlocks(blocks: any[]): Promise<NotionOverviewBlock[]> {
   const transformed: NotionOverviewBlock[] = [];
 
@@ -306,6 +345,40 @@ async function transformBlocks(blocks: any[]): Promise<NotionOverviewBlock[]> {
     };
 
     switch (block.type) {
+      case "child_database": {
+        const databaseTitle = block.child_database?.title ?? "";
+        const databaseEntries = await fetchDatabaseEntries(block.id);
+        const entries: NotionOverviewDatabaseEntry[] = databaseEntries.map(
+          (entry: any) => {
+            const entryTitle =
+              extractTitle(entry.properties ?? {}) || "제목 없음";
+            const entryUrl = entry.public_url || entry.url || "";
+            const properties = extractProperties(entry.properties ?? {});
+
+            return {
+              id: entry.id,
+              title: entryTitle,
+              url: entryUrl,
+              createdTime: entry.created_time ?? undefined,
+              lastEditedTime: entry.last_edited_time ?? undefined,
+              properties,
+            };
+          }
+        );
+
+        entries.sort((a, b) => {
+          const timeA = getTimestamp(a.lastEditedTime ?? a.createdTime);
+          const timeB = getTimestamp(b.lastEditedTime ?? b.createdTime);
+          return timeB - timeA;
+        });
+
+        base.text = databaseTitle;
+        base.database = {
+          title: databaseTitle || "연결된 데이터베이스",
+          entries,
+        };
+        break;
+      }
       case "paragraph":
       case "heading_1":
       case "heading_2":

--- a/apps/web/components/blog/BlogList.tsx
+++ b/apps/web/components/blog/BlogList.tsx
@@ -10,10 +10,13 @@ interface BlogListProps {
   loading?: boolean;
 }
 
+const sectionBaseClasses =
+  "py-20 min-h-[calc(100vh-var(--header-height)-10rem)] bg-[var(--color-background)]";
+
 function BlogListSkeleton() {
   return (
     <Layout>
-      <section className="py-20 min-h-[calc(100vh-var(--header-height))] bg-[var(--color-background)]">
+      <section className={sectionBaseClasses}>
         <div className="container mx-auto px-6 md:px-8">
           <motion.div
             className="max-w-3xl mx-auto text-center mb-16"
@@ -52,7 +55,7 @@ const BlogList: React.FC<BlogListProps> = ({ posts, loading }) => {
   if (!posts.length) {
     return (
       <Layout>
-        <section className="py-20 min-h-[calc(100vh-var(--header-height))] bg-[var(--color-background)]">
+        <section className={sectionBaseClasses}>
           <div className="container mx-auto px-6 md:px-8">
             <motion.div
               className="max-w-3xl mx-auto text-center mb-16"
@@ -97,7 +100,7 @@ const BlogList: React.FC<BlogListProps> = ({ posts, loading }) => {
 
   return (
     <Layout>
-      <section className="py-20 min-h-[calc(100vh-var(--header-height))] bg-[var(--color-background)]">
+      <section className={sectionBaseClasses}>
         <div className="container mx-auto px-6 md:px-8">
           <motion.div
             className="max-w-3xl mx-auto text-center mb-16"

--- a/apps/web/components/layout/Layout.tsx
+++ b/apps/web/components/layout/Layout.tsx
@@ -6,7 +6,7 @@ interface LayoutProps {
 
 const Layout = ({ children }: LayoutProps) => {
   return (
-    <div className="relative py-16 sm:py-20">
+    <div className="relative">
       <div className="mx-auto max-w-6xl space-y-16 px-6 sm:px-8 text-[color:var(--color-text-primary)]">
         {children}
       </div>

--- a/apps/web/components/sections/OverviewSection.tsx
+++ b/apps/web/components/sections/OverviewSection.tsx
@@ -65,6 +65,17 @@ const notionTagColorMap: Record<
   },
 };
 
+function formatDateLabel(value?: string) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
 function getTagStyles(tag: NotionOverviewTag) {
   const fallback = {
     background: "rgba(148, 163, 184, 0.16)",
@@ -296,6 +307,112 @@ function renderBlock(block: NotionOverviewBlock): ReactNode {
         </li>
       );
     }
+    case "child_database": {
+      if (!block.database) return null;
+
+      return (
+        <div key={block.id} className="space-y-5">
+          {(block.database.title || block.text) && (
+            <h3 className="text-xl font-semibold text-[color:var(--color-text-primary)]">
+              {block.database.title || block.text}
+            </h3>
+          )}
+          {block.database.entries.length === 0 ? (
+            <div className="rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/70 px-5 py-6 text-sm text-[color:var(--color-text-secondary)]">
+              연결된 데이터베이스 항목이 없습니다. 노션에서 항목을 추가하면 자동으로 반영됩니다.
+            </div>
+          ) : (
+            <div className="space-y-5">
+              {block.database.entries.map((entry) => {
+                const entryUpdatedLabel =
+                  formatDateLabel(entry.lastEditedTime ?? entry.createdTime);
+                const visibleProperties = entry.properties;
+
+                return (
+                  <article
+                    key={entry.id}
+                    className="rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/75 px-5 py-5 shadow-[0_18px_42px_var(--color-card-shadow)]/45"
+                  >
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                      <div>
+                        <h4 className="text-lg font-semibold text-[color:var(--color-text-primary)]">
+                          {entry.title || "제목 없음"}
+                        </h4>
+                        {entryUpdatedLabel && (
+                          <span className="text-xs text-[color:var(--color-text-tertiary)]">
+                            업데이트: {entryUpdatedLabel}
+                          </span>
+                        )}
+                      </div>
+                      {entry.url && (
+                        <a
+                          href={entry.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-2 rounded-full border border-[color:var(--color-border-light)] bg-[color:var(--color-background)] px-3 py-1.5 text-xs font-semibold text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-primary)] hover:text-[color:var(--color-primary)]"
+                        >
+                          노션에서 보기
+                          <svg
+                            className="h-3.5 w-3.5"
+                            viewBox="0 0 20 20"
+                            fill="none"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M11.25 3.75H16.25V8.75"
+                              stroke="currentColor"
+                              strokeWidth="1.5"
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                            />
+                            <path
+                              d="M8.75 11.25L16.25 3.75"
+                              stroke="currentColor"
+                              strokeWidth="1.5"
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                            />
+                            <path
+                              d="M8.75 3.75H5.75C4.64543 3.75 3.75 4.64543 3.75 5.75V14.25C3.75 15.3546 4.64543 16.25 5.75 16.25H14.25C15.3546 16.25 16.25 15.3546 16.25 14.25V11.5"
+                              stroke="currentColor"
+                              strokeWidth="1.5"
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                            />
+                          </svg>
+                        </a>
+                      )}
+                    </div>
+
+                    {visibleProperties.length > 0 ? (
+                      <dl className="mt-4 grid gap-3 sm:grid-cols-2">
+                        {visibleProperties.map((property) => (
+                          <div
+                            key={`${entry.id}-${property.id}`}
+                            className="rounded-xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/80 px-4 py-3"
+                          >
+                            <dt className="text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-[color:var(--color-text-tertiary)]">
+                              {property.name}
+                            </dt>
+                            <dd className="mt-2 text-sm text-[color:var(--color-text-secondary)]">
+                              {renderPropertyValue(property)}
+                            </dd>
+                          </div>
+                        ))}
+                      </dl>
+                    ) : (
+                      <p className="mt-4 text-sm text-[color:var(--color-text-tertiary)]">
+                        표시할 속성이 없습니다.
+                      </p>
+                    )}
+                  </article>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      );
+    }
     default:
       return block.text ? (
         <p
@@ -397,14 +514,7 @@ export default function OverviewSection() {
   }, [data]);
 
   const lastUpdatedLabel = useMemo(() => {
-    if (!data?.lastEditedTime) return "";
-    const date = new Date(data.lastEditedTime);
-    if (Number.isNaN(date.getTime())) return "";
-    return date.toLocaleDateString("ko-KR", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
+    return formatDateLabel(data?.lastEditedTime);
   }, [data?.lastEditedTime]);
 
   return (


### PR DESCRIPTION
## Summary
- parse Notion child database blocks in the overview API response and include entry metadata
- render fetched database entries within the overview section so Notion content shows like the tech blog cards
- tighten shared layout padding and blog section min-height so the main layout no longer scrolls unnecessarily

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cf531f2d9c83229c8a3b456b7599b5