### PR TITLE
Fix mobile layout overflow

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -221,6 +221,7 @@ html[data-theme="dark"] {
 
 html {
   scroll-behavior: smooth;
+  overflow-x: hidden;
 }
 
 body {
@@ -242,6 +243,8 @@ body {
     background-color 0.6s var(--transition-smooth),
     background-image 0.6s var(--transition-smooth);
   position: relative;
+  max-width: 100vw;
+  overflow-x: hidden;
 }
 
 body::before {


### PR DESCRIPTION
## Summary
- prevent horizontal overflow on mobile by hiding horizontal overflow at the document level

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cf959ef1908322982683b3f6a62ffe