### PR TITLE
Improve mobile layout spacing

### DIFF
--- a/apps/web/components/layout/Layout.tsx
+++ b/apps/web/components/layout/Layout.tsx
@@ -7,7 +7,7 @@ interface LayoutProps {
 const Layout = ({ children }: LayoutProps) => {
   return (
     <div className="relative">
-      <div className="mx-auto max-w-6xl space-y-16 px-6 sm:px-8 text-[color:var(--color-text-primary)]">
+      <div className="mx-auto max-w-6xl space-y-16 px-4 sm:px-6 lg:px-8 text-[color:var(--color-text-primary)]">
         {children}
       </div>
     </div>

--- a/apps/web/components/layout/SectionContainer.tsx
+++ b/apps/web/components/layout/SectionContainer.tsx
@@ -11,7 +11,7 @@ export default function SectionContainer({
 }: SectionContainerProps) {
   return (
     <section className={`py-20 ${className}`}>
-      <div className="container mx-auto px-6 md:px-8">{children}</div>
+      <div className="container mx-auto px-4 sm:px-6 md:px-8">{children}</div>
     </section>
   );
 }

--- a/apps/web/components/layout/SiteHeader.tsx
+++ b/apps/web/components/layout/SiteHeader.tsx
@@ -95,7 +95,7 @@ const SiteHeader = () => {
           : "bg-transparent"
       )}
     >
-      <div className="mx-auto flex h-[var(--header-height,4.5rem)] max-w-6xl items-center justify-between px-6 sm:px-8">
+      <div className="mx-auto flex h-[var(--header-height,4.5rem)] max-w-6xl items-center justify-between px-4 sm:px-6 lg:px-8">
         <Link
           href={getNavHref("hero")}
           className="text-lg font-semibold text-[color:var(--color-text-primary)] hover:text-[color:var(--color-primary)]"
@@ -159,7 +159,7 @@ const SiteHeader = () => {
 
       {isMenuOpen && (
         <div className="md:hidden border-t border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/95 backdrop-blur">
-          <nav className="mx-auto flex max-w-6xl flex-col px-6 py-6 sm:px-8">
+          <nav className="mx-auto flex max-w-6xl flex-col px-4 py-6 sm:px-6">
             {NAV_ITEMS.map((item) => {
               const isActive = activeId === item.id;
               return (

--- a/apps/web/components/sections/CaseStudiesSection.tsx
+++ b/apps/web/components/sections/CaseStudiesSection.tsx
@@ -15,7 +15,7 @@ const CaseStudiesSection = ({ studies }: CaseStudiesSectionProps) => {
         description="단순 기능 개발을 넘어, 실제 운영 지표를 개선하고 팀의 작업 방식을 바꾼 사례들입니다."
         align="center"
       />
-      <div className="mt-14 grid gap-8 lg:grid-cols-3">
+      <div className="mt-14 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
         {studies.map((study) => (
           <article
             key={study.title}

--- a/apps/web/components/sections/ExperienceSection.tsx
+++ b/apps/web/components/sections/ExperienceSection.tsx
@@ -20,7 +20,7 @@ const ExperienceSection = ({ experiences }: ExperienceSectionProps) => {
             key={`${experience.company}-${experience.period}`}
             className="rounded-3xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/90 p-8 shadow-lg shadow-[color:var(--color-card-shadow)]/60"
           >
-            <div className="flex flex-wrap items-start justify-between gap-6">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
               <div>
                 <p className="text-sm font-semibold uppercase tracking-[0.28em] text-[color:var(--color-text-tertiary)]">
                   {experience.company}
@@ -29,7 +29,7 @@ const ExperienceSection = ({ experiences }: ExperienceSectionProps) => {
                   {experience.role}
                 </h3>
               </div>
-              <div className="text-sm text-right text-[color:var(--color-text-secondary)]">
+              <div className="text-sm text-left text-[color:var(--color-text-secondary)] sm:text-right">
                 <p className="font-medium text-[color:var(--color-text-primary)]">
                   {experience.period}
                 </p>

--- a/apps/web/components/sections/HeroSection.tsx
+++ b/apps/web/components/sections/HeroSection.tsx
@@ -15,8 +15,8 @@ interface HeroSectionProps {
 
 const HeroSection = ({ hero, metrics, onDownloadResume }: HeroSectionProps) => {
   return (
-    <SectionContainer id="hero" className="pt-24 sm:pt-32 pb-12">
-      <div className="grid lg:grid-cols-[1.15fr_0.85fr] gap-12 lg:gap-16 items-center">
+    <SectionContainer id="hero" className="pt-20 sm:pt-28 pb-12">
+      <div className="grid gap-10 lg:grid-cols-[1.15fr_0.85fr] lg:gap-16 items-center">
         <motion.div
           initial={{ opacity: 0, y: 24 }}
           animate={{ opacity: 1, y: 0 }}
@@ -116,7 +116,7 @@ const HeroSection = ({ hero, metrics, onDownloadResume }: HeroSectionProps) => {
           <h2 className="text-sm font-semibold uppercase tracking-[0.32em] text-[color:var(--color-text-tertiary)]">
             Impact Metrics
           </h2>
-          <div className="mt-6 grid grid-cols-2 gap-6">
+          <div className="mt-6 grid grid-cols-1 gap-6 sm:grid-cols-2">
             {metrics.map((metric) => (
               <div
                 key={metric.label}

--- a/apps/web/components/sections/NotionProjectsSection.tsx
+++ b/apps/web/components/sections/NotionProjectsSection.tsx
@@ -33,7 +33,7 @@ export default function NotionProjectsSection() {
       id="projects"
       className="bg-[color:var(--color-card-background)]/35 backdrop-blur-md"
     >
-      <div className="flex flex-col items-start gap-8 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
         <SectionHeader
           eyebrow="Notion Projects"
           title="최근 프로젝트 기록"
@@ -41,7 +41,7 @@ export default function NotionProjectsSection() {
         />
         <Link
           href="/projects"
-          className="inline-flex items-center rounded-full border border-[color:var(--color-border-light)] bg-[color:var(--color-background)] px-5 py-2 text-sm font-semibold text-[color:var(--color-text-primary)] shadow-sm transition-colors hover:border-[color:var(--color-primary)] hover:text-[color:var(--color-primary)]"
+          className="inline-flex w-full items-center justify-center rounded-full border border-[color:var(--color-border-light)] bg-[color:var(--color-background)] px-5 py-2 text-sm font-semibold text-[color:var(--color-text-primary)] shadow-sm transition-colors hover:border-[color:var(--color-primary)] hover:text-[color:var(--color-primary)] sm:w-auto"
         >
           전체 프로젝트 보기
           <svg
@@ -75,7 +75,7 @@ export default function NotionProjectsSection() {
         </Link>
       </div>
 
-      <div className="mt-14 grid gap-6 md:grid-cols-3">
+      <div className="mt-12 grid gap-6 sm:grid-cols-2 md:grid-cols-3">
         {isPending &&
           skeletonCards.map((_, index) => (
             <div

--- a/apps/web/components/sections/SectionContainer.tsx
+++ b/apps/web/components/sections/SectionContainer.tsx
@@ -12,12 +12,12 @@ const SectionContainer = ({ id, className, children }: SectionContainerProps) =>
     <section
       id={id}
       className={clsx(
-        "relative py-24 sm:py-28",
+        "relative py-20 sm:py-24 lg:py-28",
         "scroll-mt-[calc(var(--header-height,4.5rem)+2rem)]",
         className
       )}
     >
-      <div className="max-w-6xl mx-auto px-6 sm:px-8">{children}</div>
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">{children}</div>
     </section>
   );
 };


### PR DESCRIPTION
## Summary
- relax default section padding and container gutters on mobile to let content breathe
- stack hero metrics and experience header content vertically for narrow viewports and widen case study/project grids responsively
- adjust header and CTA layouts so mobile buttons and nav use full-width spacing

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cfa237ee2c8322bb37779250df823a