### PR TITLE
Refine mobile spacing

### DIFF
--- a/apps/web/components/blog/BlogCard.tsx
+++ b/apps/web/components/blog/BlogCard.tsx
@@ -26,7 +26,7 @@ export default function BlogCard({ post, index = 0 }: BlogCardProps) {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5, delay: index * 0.1, ease: "easeOut" }}
       >
-        <div className="flex h-full flex-col p-6">
+        <div className="flex h-full flex-col p-5 sm:p-6">
           {/* 헤더 섹션 */}
           <div className="mb-4 flex flex-col">
             {post.category && categoryColor && (
@@ -52,7 +52,7 @@ export default function BlogCard({ post, index = 0 }: BlogCardProps) {
 
           {/* 설명 섹션 - flex-1로 남은 공간 차지 */}
           <div className="flex flex-1 flex-col">
-            <p className="mb-6 flex-1 text-sm leading-relaxed text-[color:var(--color-text-secondary)] line-clamp-3">
+            <p className="mb-5 sm:mb-6 flex-1 text-sm leading-relaxed text-[color:var(--color-text-secondary)] line-clamp-3">
               {post.description || "블로그 글의 미리보기 내용입니다."}
             </p>
           </div>

--- a/apps/web/components/projects/ProjectCard.tsx
+++ b/apps/web/components/projects/ProjectCard.tsx
@@ -24,7 +24,7 @@ export default function ProjectCard({ project, index = 0 }: ProjectCardProps) {
   return (
     <motion.div
       key={project.id}
-      className={`group relative bg-[var(--color-card-background)] border border-[var(--color-card-border)] rounded-2xl shadow-[0_2px_8px_0_rgba(59,130,246,0.06)] hover:shadow-[0_4px_16px_0_rgba(59,130,246,0.13)] transition-all duration-300 p-7 flex flex-col gap-3 items-start hover:-translate-y-1 hover:scale-[1.02] overflow-hidden ${
+      className={`group relative bg-[var(--color-card-background)] border border-[var(--color-card-border)] rounded-2xl shadow-[0_2px_8px_0_rgba(59,130,246,0.06)] hover:shadow-[0_4px_16px_0_rgba(59,130,246,0.13)] transition-all duration-300 p-6 sm:p-7 flex flex-col gap-3 items-start hover:-translate-y-1 hover:scale-[1.02] overflow-hidden ${
         project.url ? "cursor-pointer" : "cursor-default"
       }`}
       initial={{ opacity: 0, y: 20 }}

--- a/apps/web/components/sections/CaseStudiesSection.tsx
+++ b/apps/web/components/sections/CaseStudiesSection.tsx
@@ -15,11 +15,11 @@ const CaseStudiesSection = ({ studies }: CaseStudiesSectionProps) => {
         description="단순 기능 개발을 넘어, 실제 운영 지표를 개선하고 팀의 작업 방식을 바꾼 사례들입니다."
         align="center"
       />
-      <div className="mt-14 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="mt-10 sm:mt-14 grid gap-6 sm:gap-8 sm:grid-cols-2 lg:grid-cols-3">
         {studies.map((study) => (
           <article
             key={study.title}
-            className="flex h-full flex-col rounded-3xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/85 p-7 shadow-lg shadow-[color:var(--color-card-shadow)]/60"
+            className="flex h-full flex-col rounded-3xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/85 p-6 sm:p-7 shadow-lg shadow-[color:var(--color-card-shadow)]/60"
           >
             <div className="space-y-3">
               <span className="inline-flex w-fit items-center rounded-full bg-[color:var(--color-primary)]/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--color-primary)]">
@@ -32,7 +32,7 @@ const CaseStudiesSection = ({ studies }: CaseStudiesSectionProps) => {
                 {study.summary}
               </p>
             </div>
-            <ul className="mt-6 space-y-4 text-sm text-[color:var(--color-text-secondary)]">
+            <ul className="mt-5 sm:mt-6 space-y-4 text-sm text-[color:var(--color-text-secondary)]">
               {study.highlights.map((highlight) => (
                 <li key={highlight} className="flex items-start gap-3">
                   <span className="mt-1 inline-flex h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[color:var(--color-primary)]" />
@@ -40,11 +40,11 @@ const CaseStudiesSection = ({ studies }: CaseStudiesSectionProps) => {
                 </li>
               ))}
             </ul>
-            <div className="mt-6 flex flex-wrap gap-3">
+            <div className="mt-5 sm:mt-6 flex flex-wrap gap-3">
               {study.metrics.map((metric) => (
                 <div
                   key={`${study.title}-${metric.label}`}
-                  className="rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/70 px-4 py-3"
+                  className="rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/70 px-4 py-2.5 sm:py-3"
                 >
                   <p className="text-xl font-semibold text-[color:var(--color-text-primary)]">
                     {metric.value}
@@ -55,7 +55,7 @@ const CaseStudiesSection = ({ studies }: CaseStudiesSectionProps) => {
                 </div>
               ))}
             </div>
-            <div className="mt-6 flex flex-wrap gap-2 pt-4">
+            <div className="mt-5 sm:mt-6 flex flex-wrap gap-2 pt-3 sm:pt-4">
               {study.stack.map((tech) => (
                 <span
                   key={`${study.title}-${tech}`}

--- a/apps/web/components/sections/ContactSection.tsx
+++ b/apps/web/components/sections/ContactSection.tsx
@@ -25,18 +25,18 @@ const ContactSection = ({
         description="제품 목표와 팀 상황을 알려주시면, 가장 빠르게 임팩트를 낼 수 있는 전략과 실행 계획을 제안드릴게요."
         align="center"
       />
-      <div className="mt-14 grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
-        <div className="rounded-3xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/90 p-8 shadow-lg shadow-[color:var(--color-card-shadow)]/50">
+      <div className="mt-10 sm:mt-14 grid gap-6 sm:gap-8 lg:grid-cols-[1.1fr_0.9fr]">
+        <div className="rounded-3xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/90 p-6 sm:p-8 shadow-lg shadow-[color:var(--color-card-shadow)]/50">
           <h3 className="text-2xl font-semibold text-[color:var(--color-text-primary)]">
             전략부터 실행까지 함께하는 파트너가 필요하신가요?
           </h3>
-          <p className="mt-4 text-sm text-[color:var(--color-text-secondary)] leading-relaxed">
+          <p className="mt-3 sm:mt-4 text-sm text-[color:var(--color-text-secondary)] leading-relaxed">
             제품 로드맵 검토, 디자인 시스템 구축, 운영툴 고도화 등 어떤 주제든 편하게 이야기를 나눠요. 팀의 현재 페인포인트를 들으며 가장 임팩트가 큰 첫 번째 실험을 찾아드립니다.
           </p>
-          <div className="mt-8 flex flex-wrap gap-3">
+          <div className="mt-6 sm:mt-8 flex flex-wrap gap-3">
             <button
               onClick={onDownloadResume}
-              className="inline-flex items-center gap-2 rounded-full bg-[color:var(--color-primary)] px-5 py-3 text-sm font-semibold text-white shadow-md shadow-[color:var(--color-primary)]/35 transition-transform duration-200 hover:scale-[1.02]"
+              className="inline-flex items-center gap-2 rounded-full bg-[color:var(--color-primary)] px-5 py-2.5 sm:py-3 text-sm font-semibold text-white shadow-md shadow-[color:var(--color-primary)]/35 transition-transform duration-200 hover:scale-[1.02]"
             >
               이력서 PDF 받기
               <svg
@@ -56,7 +56,7 @@ const ContactSection = ({
             </button>
             <a
               href={`mailto:${email}`}
-              className="inline-flex items-center gap-2 rounded-full border border-[color:var(--color-border-normal)] px-5 py-3 text-sm font-semibold text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-primary)] hover:text-[color:var(--color-primary)]"
+              className="inline-flex items-center gap-2 rounded-full border border-[color:var(--color-border-normal)] px-5 py-2.5 sm:py-3 text-sm font-semibold text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-primary)] hover:text-[color:var(--color-primary)]"
             >
               메일 보내기
               <svg
@@ -74,8 +74,8 @@ const ContactSection = ({
             </a>
           </div>
         </div>
-        <div className="rounded-3xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/75 p-8">
-          <dl className="space-y-5 text-sm text-[color:var(--color-text-secondary)]">
+        <div className="rounded-3xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/75 p-6 sm:p-8">
+          <dl className="space-y-4 sm:space-y-5 text-sm text-[color:var(--color-text-secondary)]">
             <div>
               <dt className="text-xs uppercase tracking-[0.3em] text-[color:var(--color-text-tertiary)]">
                 Availability
@@ -93,14 +93,14 @@ const ContactSection = ({
               </dd>
             </div>
           </dl>
-          <div className="mt-6 space-y-4">
+          <div className="mt-5 sm:mt-6 space-y-3 sm:space-y-4">
             {contactChannels.map((channel) => (
               <a
                 key={channel.label}
                 href={channel.href}
                 target={channel.href.startsWith("http") ? "_blank" : undefined}
                 rel={channel.href.startsWith("http") ? "noopener noreferrer" : undefined}
-                className="flex items-center justify-between rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/90 px-5 py-4 text-sm font-medium text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-primary)]"
+                className="flex items-center justify-between rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/90 px-4 py-3 sm:px-5 sm:py-4 text-sm font-medium text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-primary)]"
               >
                 <span>{channel.label}</span>
                 <span className="text-[color:var(--color-text-secondary)]">{channel.value}</span>

--- a/apps/web/components/sections/CultureSection.tsx
+++ b/apps/web/components/sections/CultureSection.tsx
@@ -18,7 +18,7 @@ const CultureSection = ({ signals }: CultureSectionProps) => {
         {signals.map((signal) => (
           <article
             key={signal.title}
-            className="rounded-3xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/85 p-6 shadow-sm"
+            className="rounded-3xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/85 p-5 sm:p-6 shadow-sm"
           >
             <h3 className="text-lg font-semibold text-[color:var(--color-text-primary)]">
               {signal.title}

--- a/apps/web/components/sections/ExperienceSection.tsx
+++ b/apps/web/components/sections/ExperienceSection.tsx
@@ -14,11 +14,11 @@ const ExperienceSection = ({ experiences }: ExperienceSectionProps) => {
         title="도메인을 넘나들며 증명한 실행력"
         description="운영툴, 커머스, 데이터 솔루션까지 다양한 제품군에서 핵심 문제를 해결하며 팀의 개발 문화를 정비했습니다."
       />
-      <div className="mt-12 space-y-10">
+      <div className="mt-10 sm:mt-12 space-y-8 sm:space-y-10">
         {experiences.map((experience) => (
           <article
             key={`${experience.company}-${experience.period}`}
-            className="rounded-3xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/90 p-8 shadow-lg shadow-[color:var(--color-card-shadow)]/60"
+            className="rounded-3xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/90 p-6 sm:p-8 shadow-lg shadow-[color:var(--color-card-shadow)]/60"
           >
             <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
               <div>
@@ -36,25 +36,25 @@ const ExperienceSection = ({ experiences }: ExperienceSectionProps) => {
                 <p>{experience.location}</p>
               </div>
             </div>
-            <p className="mt-6 text-[color:var(--color-text-secondary)] leading-relaxed">
+            <p className="mt-5 sm:mt-6 text-[color:var(--color-text-secondary)] leading-relaxed">
               {experience.summary}
             </p>
-            <ul className="mt-6 grid gap-3 text-sm text-[color:var(--color-text-secondary)]">
+            <ul className="mt-5 sm:mt-6 grid gap-3 text-sm text-[color:var(--color-text-secondary)]">
               {experience.achievements.map((achievement) => (
                 <li
                   key={achievement}
-                  className="rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/60 px-4 py-3"
+                  className="rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/60 px-4 py-2.5 sm:py-3"
                 >
                   {achievement}
                 </li>
               ))}
             </ul>
             {experience.impacts && (
-              <div className="mt-6 flex flex-wrap gap-3">
+              <div className="mt-5 sm:mt-6 flex flex-wrap gap-3">
                 {experience.impacts.map((impact) => (
                   <div
                     key={`${experience.company}-${impact.label}`}
-                    className="rounded-full border border-[color:var(--color-border-normal)] bg-[color:var(--color-background)]/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--color-text-secondary)]"
+                    className="rounded-full border border-[color:var(--color-border-normal)] bg-[color:var(--color-background)]/80 px-4 py-1.5 sm:py-2 text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--color-text-secondary)]"
                   >
                     <span className="mr-2 text-base font-semibold text-[color:var(--color-text-primary)]">
                       {impact.value}
@@ -64,7 +64,7 @@ const ExperienceSection = ({ experiences }: ExperienceSectionProps) => {
                 ))}
               </div>
             )}
-            <div className="mt-6 flex flex-wrap gap-2">
+            <div className="mt-5 sm:mt-6 flex flex-wrap gap-2">
               {experience.stack.map((tech) => (
                 <span
                   key={`${experience.company}-${tech}`}

--- a/apps/web/components/sections/ExpertiseSection.tsx
+++ b/apps/web/components/sections/ExpertiseSection.tsx
@@ -14,11 +14,11 @@ const ExpertiseSection = ({ pillars }: ExpertiseSectionProps) => {
         title="스케일업을 위한 프론트엔드 역량"
         description="프론트엔드 아키텍처부터 데이터 기반 실험, 협업 체계 구축까지 제품 팀이 필요로 하는 전 과정을 지원합니다."
       />
-      <div className="mt-12 grid gap-6 md:grid-cols-2">
+      <div className="mt-10 sm:mt-12 grid gap-5 sm:gap-6 md:grid-cols-2">
         {pillars.map((pillar) => (
           <article
             key={pillar.title}
-            className="h-full rounded-3xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/85 p-6 shadow-md"
+            className="h-full rounded-3xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/85 p-5 sm:p-6 shadow-md"
           >
             <h3 className="text-xl font-semibold text-[color:var(--color-text-primary)]">
               {pillar.title}

--- a/apps/web/components/sections/FocusSection.tsx
+++ b/apps/web/components/sections/FocusSection.tsx
@@ -17,11 +17,11 @@ const FocusSection = ({ areas }: FocusSectionProps) => {
         title="사용자 가치와 비즈니스 임팩트를 동시에 추구합니다"
         description="다양한 도메인에서 반복적으로 검증된 방법론과 실행력을 바탕으로, 팀이 원하는 속도로 실험하고 성장할 수 있는 환경을 만듭니다."
       />
-      <div className="mt-12 grid gap-6 md:grid-cols-3">
+      <div className="mt-10 sm:mt-12 grid gap-5 sm:gap-6 md:grid-cols-3">
         {areas.map((area) => (
           <article
             key={area.title}
-            className="h-full rounded-3xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/80 p-6 shadow-sm transition-transform duration-300 hover:-translate-y-1"
+            className="h-full rounded-3xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/80 p-5 sm:p-6 shadow-sm transition-transform duration-300 hover:-translate-y-1"
           >
             <h3 className="text-xl font-semibold text-[color:var(--color-text-primary)]">
               {area.title}

--- a/apps/web/components/sections/HeroSection.tsx
+++ b/apps/web/components/sections/HeroSection.tsx
@@ -15,13 +15,13 @@ interface HeroSectionProps {
 
 const HeroSection = ({ hero, metrics, onDownloadResume }: HeroSectionProps) => {
   return (
-    <SectionContainer id="hero" className="pt-20 sm:pt-28 pb-12">
-      <div className="grid gap-10 lg:grid-cols-[1.15fr_0.85fr] lg:gap-16 items-center">
+    <SectionContainer id="hero" className="pt-16 sm:pt-28 pb-10 sm:pb-12">
+      <div className="grid gap-8 lg:grid-cols-[1.15fr_0.85fr] lg:gap-16 items-center">
         <motion.div
           initial={{ opacity: 0, y: 24 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, ease: "easeOut" }}
-          className="space-y-8"
+          className="space-y-6 sm:space-y-8"
         >
           <span className="inline-flex items-center gap-2 rounded-full border border-[color:var(--color-border-normal)] bg-[color:var(--color-card-background)] px-4 py-1.5 text-sm font-medium text-[color:var(--color-text-secondary)]">
             {hero.badge}
@@ -35,7 +35,7 @@ const HeroSection = ({ hero, metrics, onDownloadResume }: HeroSectionProps) => {
             </p>
           </div>
           <div className="grid gap-4 sm:grid-cols-2">
-            <div className="rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/80 p-5 shadow-sm">
+            <div className="rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/80 p-4 sm:p-5 shadow-sm">
               <p className="text-xs uppercase tracking-[0.28em] text-[color:var(--color-text-tertiary)]">
                 현재 집중하고 있는 일
               </p>
@@ -43,7 +43,7 @@ const HeroSection = ({ hero, metrics, onDownloadResume }: HeroSectionProps) => {
                 {hero.currentFocus}
               </p>
             </div>
-            <div className="rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/80 p-5 shadow-sm">
+            <div className="rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/80 p-4 sm:p-5 shadow-sm">
               <p className="text-xs uppercase tracking-[0.28em] text-[color:var(--color-text-tertiary)]">
                 Working Style
               </p>
@@ -111,16 +111,16 @@ const HeroSection = ({ hero, metrics, onDownloadResume }: HeroSectionProps) => {
           initial={{ opacity: 0, y: 32 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.15, duration: 0.6, ease: "easeOut" }}
-          className="rounded-3xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/90 p-8 shadow-xl shadow-[color:var(--color-card-shadow)]/70 backdrop-blur"
+          className="rounded-3xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/90 p-6 sm:p-8 shadow-xl shadow-[color:var(--color-card-shadow)]/70 backdrop-blur"
         >
           <h2 className="text-sm font-semibold uppercase tracking-[0.32em] text-[color:var(--color-text-tertiary)]">
             Impact Metrics
           </h2>
-          <div className="mt-6 grid grid-cols-1 gap-6 sm:grid-cols-2">
+          <div className="mt-5 sm:mt-6 grid grid-cols-1 gap-5 sm:gap-6 sm:grid-cols-2">
             {metrics.map((metric) => (
               <div
                 key={metric.label}
-                className="rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/60 px-4 py-5"
+                className="rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/60 px-4 py-4 sm:py-5"
               >
                 <p className="text-2xl font-semibold text-[color:var(--color-text-primary)]">
                   {metric.value}

--- a/apps/web/components/sections/NotionBlogSection.tsx
+++ b/apps/web/components/sections/NotionBlogSection.tsx
@@ -29,7 +29,7 @@ export default function NotionBlogSection() {
       id="blog"
       className="bg-[color:var(--color-background)]"
     >
-      <div className="flex flex-col items-start gap-8 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col items-start gap-6 sm:flex-row sm:items-center sm:justify-between sm:gap-8">
         <SectionHeader
           eyebrow="Tech Blog"
           title="기술 블로그"
@@ -71,12 +71,12 @@ export default function NotionBlogSection() {
         </Link>
       </div>
 
-      <div className="mt-14 grid gap-6 md:grid-cols-3">
+      <div className="mt-10 sm:mt-14 grid gap-5 sm:gap-6 md:grid-cols-3">
         {isPending &&
           skeletonCards.map((_, index) => (
             <div
               key={`blog-skeleton-${index}`}
-              className="h-full rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/80 p-6 shadow-sm"
+              className="h-full rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/80 p-5 sm:p-6 shadow-sm"
             >
               <div className="mb-4 h-6 w-20 rounded-full bg-[color:var(--color-border-normal)]/40" />
               <div className="mb-3 h-6 w-5/6 rounded bg-[color:var(--color-border-normal)]/30" />
@@ -88,13 +88,13 @@ export default function NotionBlogSection() {
           ))}
 
         {error && !isPending && (
-          <div className="col-span-full rounded-2xl border border-red-300/40 bg-red-50/60 p-6 text-sm text-red-600">
+          <div className="col-span-full rounded-2xl border border-red-300/40 bg-red-50/60 p-5 sm:p-6 text-sm text-red-600">
             블로그 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
           </div>
         )}
 
         {!isPending && !error && posts.length === 0 && (
-          <div className="col-span-full rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/80 p-8 text-center text-[color:var(--color-text-secondary)]">
+          <div className="col-span-full rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/80 p-6 sm:p-8 text-center text-[color:var(--color-text-secondary)]">
             게시된 글이 없습니다. Notion에 글을 작성하면 여기에서 확인할 수 있습니다.
           </div>
         )}

--- a/apps/web/components/sections/NotionProjectsSection.tsx
+++ b/apps/web/components/sections/NotionProjectsSection.tsx
@@ -33,7 +33,7 @@ export default function NotionProjectsSection() {
       id="projects"
       className="bg-[color:var(--color-card-background)]/35 backdrop-blur-md"
     >
-      <div className="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
         <SectionHeader
           eyebrow="Notion Projects"
           title="최근 프로젝트 기록"
@@ -75,12 +75,12 @@ export default function NotionProjectsSection() {
         </Link>
       </div>
 
-      <div className="mt-12 grid gap-6 sm:grid-cols-2 md:grid-cols-3">
+      <div className="mt-10 sm:mt-12 grid gap-5 sm:gap-6 sm:grid-cols-2 md:grid-cols-3">
         {isPending &&
           skeletonCards.map((_, index) => (
             <div
               key={`projects-skeleton-${index}`}
-              className="h-full rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/70 p-7 shadow-sm"
+              className="h-full rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/70 p-6 sm:p-7 shadow-sm"
             >
               <div className="mb-4 h-6 w-24 rounded-full bg-[color:var(--color-border-normal)]/40" />
               <div className="mb-2 h-6 w-3/4 rounded bg-[color:var(--color-border-normal)]/30" />
@@ -92,13 +92,13 @@ export default function NotionProjectsSection() {
           ))}
 
         {error && !isPending && (
-          <div className="col-span-full rounded-2xl border border-red-300/40 bg-red-50/60 p-6 text-sm text-red-600">
+          <div className="col-span-full rounded-2xl border border-red-300/40 bg-red-50/60 p-5 sm:p-6 text-sm text-red-600">
             프로젝트 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
           </div>
         )}
 
         {!isPending && !error && projects.length === 0 && (
-          <div className="col-span-full rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/70 p-8 text-center text-[color:var(--color-text-secondary)]">
+          <div className="col-span-full rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/70 p-6 sm:p-8 text-center text-[color:var(--color-text-secondary)]">
             표시할 프로젝트가 없습니다. Notion에서 프로젝트를 등록하면 자동으로 이곳에 나타납니다.
           </div>
         )}

--- a/apps/web/components/sections/OverviewSection.tsx
+++ b/apps/web/components/sections/OverviewSection.tsx
@@ -599,13 +599,13 @@ export default function OverviewSection() {
       id="overview"
       className="bg-[color:var(--color-card-background)]/30 backdrop-blur-sm"
     >
-      <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
+      <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
         <SectionHeader
           eyebrow="Resume Overview"
           title={data?.title || "자기소개 Overview"}
           description="Notion 페이지와 연동된 최신 자기소개 이력을 확인할 수 있습니다."
         />
-        <div className="flex flex-col items-start gap-3 text-xs text-[color:var(--color-text-tertiary)] sm:items-end">
+        <div className="flex flex-col items-start gap-2.5 sm:gap-3 text-xs text-[color:var(--color-text-tertiary)] sm:items-end">
           {lastUpdatedLabel && <span>업데이트: {lastUpdatedLabel}</span>}
           {data?.url && (
             <Link
@@ -648,9 +648,9 @@ export default function OverviewSection() {
         </div>
       </div>
 
-      <div className="mt-10 rounded-3xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/85 p-8 shadow-lg shadow-[color:var(--color-card-shadow)]/40">
+      <div className="mt-10 rounded-3xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/85 p-6 sm:p-8 shadow-lg shadow-[color:var(--color-card-shadow)]/40">
         {isPending && (
-          <div className="space-y-10">
+          <div className="space-y-8 sm:space-y-10">
             <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
               {propertySkeletons.map((_, index) => (
                 <div
@@ -663,7 +663,7 @@ export default function OverviewSection() {
               ))}
             </div>
 
-            <div className="space-y-6">
+            <div className="space-y-5 sm:space-y-6">
               <div className="h-5 w-40 rounded bg-[color:var(--color-border-normal)]/30" />
               {skeletonParagraphs.map((_, index) => (
                 <div key={`overview-skeleton-${index}`} className="space-y-2">
@@ -677,7 +677,7 @@ export default function OverviewSection() {
         )}
 
         {error && !isPending && (
-          <div className="rounded-2xl border border-red-300/40 bg-red-50/70 p-6 text-sm text-red-600">
+          <div className="rounded-2xl border border-red-300/40 bg-red-50/70 p-5 sm:p-6 text-sm text-red-600">
             {error.message}
           </div>
         )}
@@ -685,20 +685,20 @@ export default function OverviewSection() {
         {!isPending && !error && data &&
           renderedProperties.length === 0 &&
           renderedBlocks.length === 0 && (
-          <div className="rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/80 p-6 text-sm text-[color:var(--color-text-secondary)]">
+          <div className="rounded-2xl border border-[color:var(--color-border-light)] bg-[color:var(--color-card-background)]/80 p-5 sm:p-6 text-sm text-[color:var(--color-text-secondary)]">
             표시할 자기소개 블록이 없습니다. 노션 페이지에 내용을 추가하면 자동으로 반영됩니다.
           </div>
         )}
 
         {!isPending && !error && (renderedProperties.length > 0 || renderedBlocks.length > 0) && (
-          <div className="space-y-8">
+          <div className="space-y-6 sm:space-y-8">
             {renderedProperties.length > 0 && (
               <dl className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
                 {renderedProperties}
               </dl>
             )}
             {renderedBlocks.length > 0 && (
-              <div className="space-y-6">{renderedBlocks}</div>
+              <div className="space-y-5 sm:space-y-6">{renderedBlocks}</div>
             )}
           </div>
         )}

--- a/apps/web/components/sections/SectionContainer.tsx
+++ b/apps/web/components/sections/SectionContainer.tsx
@@ -12,7 +12,7 @@ const SectionContainer = ({ id, className, children }: SectionContainerProps) =>
     <section
       id={id}
       className={clsx(
-        "relative py-20 sm:py-24 lg:py-28",
+        "relative py-12 sm:py-20 lg:py-28",
         "scroll-mt-[calc(var(--header-height,4.5rem)+2rem)]",
         className
       )}


### PR DESCRIPTION
## Summary
- reduce default section padding and hero spacing for better readability on small screens
- tighten card and list paddings across experience, case study, blog, and project sections
- adjust contact section buttons and detail blocks to sit closer together on mobile

## Testing
- pnpm --filter web lint

------
https://chatgpt.com/codex/tasks/task_e_68cfba642d3483229828c0e47b789a71