### PR TITLE
feat(web): use radix dialog for blog/project modals

### DIFF
--- a/apps/web/components/ui/Modal.tsx
+++ b/apps/web/components/ui/Modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { ReactNode, useEffect, useId } from "react";
+import { ReactNode, useCallback } from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
 
 interface ModalProps {
   isOpen: boolean;
@@ -17,83 +18,61 @@ const sizeClassMap: Record<NonNullable<ModalProps["size"]>, string> = {
 };
 
 const Modal = ({ isOpen, onClose, title, description, children, size = "lg" }: ModalProps) => {
-  const generatedId = useId();
-  const titleId = `modal-title-${generatedId}`;
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
         onClose();
       }
-    };
+    },
+    [onClose],
+  );
 
-    const originalOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    document.addEventListener("keydown", handleKeyDown);
-
-    return () => {
-      document.body.style.overflow = originalOverflow;
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [isOpen, onClose]);
-
-  if (!isOpen) {
-    return null;
-  }
+  const sizeClass = sizeClassMap[size];
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div
-        className="absolute inset-0 bg-[color:var(--color-overlay)] backdrop-blur-sm"
-        onClick={onClose}
-        aria-hidden
-      />
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={titleId}
-        className={`relative z-10 w-full ${sizeClassMap[size]} rounded-3xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/95 p-6 shadow-[0_28px_68px_var(--color-card-shadow)] backdrop-blur`}
-      >
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <h2 id={titleId} className="text-2xl font-semibold text-[color:var(--color-text-primary)]">
-              {title}
-            </h2>
-            {description ? (
-              <p className="mt-2 text-sm text-[color:var(--color-text-secondary)] leading-relaxed">
-                {description}
-              </p>
-            ) : null}
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-[color:var(--color-border-normal)] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-primary)] hover:text-[color:var(--color-primary)]"
-            aria-label="모달 닫기"
-          >
-            <svg
-              viewBox="0 0 24 24"
-              width="16"
-              height="16"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
+    <DialogPrimitive.Root open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-[color:var(--color-overlay)] backdrop-blur-sm" />
+        <DialogPrimitive.Content
+          className={`fixed left-1/2 top-1/2 z-50 w-[calc(100vw-2rem)] ${sizeClass} max-h-[85vh] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-3xl border border-[color:var(--color-border-light)] bg-[color:var(--color-background)]/95 p-6 shadow-[0_28px_68px_var(--color-card-shadow)] backdrop-blur focus:outline-none`}
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <DialogPrimitive.Title className="text-2xl font-semibold text-[color:var(--color-text-primary)]">
+                {title}
+              </DialogPrimitive.Title>
+              {description ? (
+                <DialogPrimitive.Description className="mt-2 text-sm leading-relaxed text-[color:var(--color-text-secondary)]">
+                  {description}
+                </DialogPrimitive.Description>
+              ) : null}
+            </div>
+            <DialogPrimitive.Close
+              type="button"
+              className="inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-[color:var(--color-border-normal)] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-primary)] hover:text-[color:var(--color-primary)]"
+              aria-label="모달 닫기"
             >
-              <line x1="18" y1="6" x2="6" y2="18" />
-              <line x1="6" y1="6" x2="18" y2="18" />
-            </svg>
-          </button>
-        </div>
-        <div className="mt-6 max-h-[70vh] overflow-y-auto pr-2">
-          {children}
-        </div>
-      </div>
-    </div>
+              <svg
+                viewBox="0 0 24 24"
+                width="16"
+                height="16"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </DialogPrimitive.Close>
+          </div>
+          <div className="mt-6 max-h-[70vh] overflow-y-auto pr-2">
+            {children}
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
   );
 };
 

--- a/apps/web/lib/radix-ui/react-dialog.tsx
+++ b/apps/web/lib/radix-ui/react-dialog.tsx
@@ -1,0 +1,298 @@
+import {
+  ComponentPropsWithoutRef,
+  ElementRef,
+  ForwardedRef,
+  ReactNode,
+  createContext,
+  forwardRef,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+
+interface DialogContextValue {
+  open: boolean;
+  setOpen: (nextOpen: boolean) => void;
+  titleId?: string;
+  descriptionId?: string;
+  setTitleId: (id?: string) => void;
+  setDescriptionId: (id?: string) => void;
+}
+
+const DialogContext = createContext<DialogContextValue | null>(null);
+
+function useDialogContext(component: string): DialogContextValue {
+  const context = useContext(DialogContext);
+  if (!context) {
+    throw new Error(`${component} must be used within <Dialog.Root />`);
+  }
+  return context;
+}
+
+function setForwardedRef<T>(ref: ForwardedRef<T>, value: T) {
+  if (typeof ref === "function") {
+    ref(value);
+  } else if (ref) {
+    ref.current = value;
+  }
+}
+
+export interface DialogRootProps {
+  children?: ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+const DialogRoot = ({ children, open, defaultOpen = false, onOpenChange }: DialogRootProps) => {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
+  const [titleId, setTitleId] = useState<string | undefined>();
+  const [descriptionId, setDescriptionId] = useState<string | undefined>();
+
+  const isControlled = open !== undefined;
+  const currentOpen = isControlled ? open : uncontrolledOpen;
+
+  const setOpen = useCallback(
+    (nextOpen: boolean) => {
+      if (!isControlled) {
+        setUncontrolledOpen(nextOpen);
+      }
+      onOpenChange?.(nextOpen);
+    },
+    [isControlled, onOpenChange],
+  );
+
+  const value = useMemo(
+    () => ({
+      open: currentOpen,
+      setOpen,
+      titleId,
+      descriptionId,
+      setTitleId,
+      setDescriptionId,
+    }),
+    [currentOpen, setOpen, titleId, descriptionId],
+  );
+
+  return <DialogContext.Provider value={value}>{children}</DialogContext.Provider>;
+};
+
+interface DialogPortalProps {
+  children?: ReactNode;
+}
+
+const DialogPortal = ({ children }: DialogPortalProps) => {
+  const { open } = useDialogContext("Dialog.Portal");
+
+  if (!open) {
+    return null;
+  }
+
+  if (typeof document === "undefined") {
+    return <>{children}</>;
+  }
+
+  return createPortal(children, document.body);
+};
+
+export type DialogOverlayProps = ComponentPropsWithoutRef<"div">;
+
+const DialogOverlay = forwardRef<ElementRef<"div">, DialogOverlayProps>(
+  ({ onClick, ...props }, ref) => {
+    const { open, setOpen } = useDialogContext("Dialog.Overlay");
+
+    if (!open) {
+      return null;
+    }
+
+    return (
+      <div
+        {...props}
+        ref={ref}
+        data-state={open ? "open" : "closed"}
+        onClick={(event) => {
+          onClick?.(event);
+          if (!event.defaultPrevented) {
+            setOpen(false);
+          }
+        }}
+      />
+    );
+  },
+);
+
+DialogOverlay.displayName = "DialogOverlay";
+
+export type DialogContentProps = ComponentPropsWithoutRef<"div">;
+
+const DialogContent = forwardRef<ElementRef<"div">, DialogContentProps>(
+  ({ children, tabIndex, onKeyDown, ...props }, ref) => {
+    const { open, setOpen, titleId, descriptionId } = useDialogContext("Dialog.Content");
+    const contentRef = useRef<ElementRef<"div"> | null>(null);
+
+    useEffect(() => {
+      if (!open) {
+        return;
+      }
+
+      const node = contentRef.current;
+      const previouslyFocused = document.activeElement as HTMLElement | null;
+
+      if (node && typeof node.focus === "function") {
+        node.focus({ preventScroll: true });
+      }
+
+      const handleKeyDown = (event: KeyboardEvent) => {
+        if (event.key === "Escape") {
+          event.stopPropagation();
+          setOpen(false);
+        }
+      };
+
+      const previousOverflow = document.body.style.overflow;
+      document.body.style.overflow = "hidden";
+      document.addEventListener("keydown", handleKeyDown);
+
+      return () => {
+        document.body.style.overflow = previousOverflow;
+        document.removeEventListener("keydown", handleKeyDown);
+        previouslyFocused?.focus?.({ preventScroll: true });
+      };
+    }, [open, setOpen]);
+
+    if (!open) {
+      return null;
+    }
+
+    return (
+      <div
+        {...props}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        tabIndex={tabIndex ?? -1}
+        data-state={open ? "open" : "closed"}
+        ref={(node) => {
+          contentRef.current = node;
+          setForwardedRef(ref, node);
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            event.stopPropagation();
+            setOpen(false);
+          }
+          onKeyDown?.(event);
+        }}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+
+DialogContent.displayName = "DialogContent";
+
+export type DialogTitleProps = ComponentPropsWithoutRef<"h2">;
+
+const DialogTitle = forwardRef<ElementRef<"h2">, DialogTitleProps>(({ id, ...props }, ref) => {
+  const { setTitleId } = useDialogContext("Dialog.Title");
+  const autoId = useId();
+  const titleId = id ?? autoId;
+
+  useEffect(() => {
+    setTitleId(titleId);
+    return () => {
+      setTitleId(undefined);
+    };
+  }, [setTitleId, titleId]);
+
+  return <h2 {...props} id={titleId} ref={ref} />;
+});
+
+DialogTitle.displayName = "DialogTitle";
+
+export type DialogDescriptionProps = ComponentPropsWithoutRef<"p">;
+
+const DialogDescription = forwardRef<ElementRef<"p">, DialogDescriptionProps>(
+  ({ id, ...props }, ref) => {
+    const { setDescriptionId } = useDialogContext("Dialog.Description");
+    const autoId = useId();
+    const descriptionId = id ?? autoId;
+
+    useEffect(() => {
+      setDescriptionId(descriptionId);
+      return () => {
+        setDescriptionId(undefined);
+      };
+    }, [setDescriptionId, descriptionId]);
+
+    return <p {...props} id={descriptionId} ref={ref} />;
+  },
+);
+
+DialogDescription.displayName = "DialogDescription";
+
+export type DialogCloseProps = ComponentPropsWithoutRef<"button">;
+
+const DialogClose = forwardRef<ElementRef<"button">, DialogCloseProps>(
+  ({ onClick, type = "button", ...props }, ref) => {
+    const { setOpen } = useDialogContext("Dialog.Close");
+
+    return (
+      <button
+        {...props}
+        ref={ref}
+        type={type}
+        onClick={(event) => {
+          onClick?.(event);
+          if (!event.defaultPrevented) {
+            setOpen(false);
+          }
+        }}
+      />
+    );
+  },
+);
+
+DialogClose.displayName = "DialogClose";
+
+export type DialogTriggerProps = ComponentPropsWithoutRef<"button">;
+
+const DialogTrigger = forwardRef<ElementRef<"button">, DialogTriggerProps>(
+  ({ onClick, type = "button", ...props }, ref) => {
+    const { setOpen } = useDialogContext("Dialog.Trigger");
+
+    return (
+      <button
+        {...props}
+        ref={ref}
+        type={type}
+        onClick={(event) => {
+          onClick?.(event);
+          if (!event.defaultPrevented) {
+            setOpen(true);
+          }
+        }}
+      />
+    );
+  },
+);
+
+DialogTrigger.displayName = "DialogTrigger";
+
+export {
+  DialogRoot as Root,
+  DialogPortal as Portal,
+  DialogOverlay as Overlay,
+  DialogContent as Content,
+  DialogTitle as Title,
+  DialogDescription as Description,
+  DialogClose as Close,
+  DialogTrigger as Trigger,
+};

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -6,7 +6,8 @@
       "@/components/*": ["components/*"],
       "@/app/*": ["app/*"],
       "@/utils/*": ["utils/*"],
-      "@/constants/*": ["constants/*"]
+      "@/constants/*": ["constants/*"],
+      "@radix-ui/react-dialog": ["lib/radix-ui/react-dialog"]
     },
     "plugins": [
       {


### PR DESCRIPTION
## Summary
- replace the home modal implementation with a Radix-style dialog API for better accessibility and consistency
- add a local Radix Dialog primitive implementation and wire a path alias so it can be reused across the app

## Testing
- pnpm --filter web lint
- pnpm --filter web check-types

------
https://chatgpt.com/codex/tasks/task_e_68d0067deed88322860eb34d65405856